### PR TITLE
feat(scorerebound): database schema — tables, RLS, migrations, types

### DIFF
--- a/scorerebound/bun.lock
+++ b/scorerebound/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "scorerebound",
       "dependencies": {
+        "@supabase/supabase-js": "^2.99.2",
         "next": "^15.3.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -318,6 +319,18 @@
 
     "@rushstack/eslint-patch": ["@rushstack/eslint-patch@1.16.1", "", {}, "sha512-TvZbIpeKqGQQ7X0zSCvPH9riMSFQFSggnfBjFZ1mEoILW+UuXCKwOoPcgjMwiUtRqFZ8jWhPJc4um14vC6I4ag=="],
 
+    "@supabase/auth-js": ["@supabase/auth-js@2.99.2", "", { "dependencies": { "tslib": "2.8.1" } }, "sha512-uRGNXMKEw4VhwouNW7N0XDAGqJP9redHNDmWi17dTrcO1lvFfyRiXsqqfgnVC8aqtRn8kLkLPEzHjiRWsni+oQ=="],
+
+    "@supabase/functions-js": ["@supabase/functions-js@2.99.2", "", { "dependencies": { "tslib": "2.8.1" } }, "sha512-xuXQARvjdfB1UPK1yUceZ5EGjOLkVz4rBAaloS9foXiAuseWEdgWBCxkIAFRxGBLGX8Uzo8kseq90jhPb+07Vg=="],
+
+    "@supabase/postgrest-js": ["@supabase/postgrest-js@2.99.2", "", { "dependencies": { "tslib": "2.8.1" } }, "sha512-ueiOVkbkTQ7RskwVmjR8zxWYw3VKOMxo1+qep+Dx/SgApqyhWBGd92waQb45tbLc7ydB5x8El8utXOLQTuTojQ=="],
+
+    "@supabase/realtime-js": ["@supabase/realtime-js@2.99.2", "", { "dependencies": { "@types/phoenix": "^1.6.6", "@types/ws": "^8.18.1", "tslib": "2.8.1", "ws": "^8.18.2" } }, "sha512-J6Jm9601dkpZf3+EJ48ki2pM4sFtCNm/BI0l8iEnrczgg+JSEQkMoOW5VSpM54t0pNs69bsz5PTmYJahDZKiIQ=="],
+
+    "@supabase/storage-js": ["@supabase/storage-js@2.99.2", "", { "dependencies": { "iceberg-js": "^0.8.1", "tslib": "2.8.1" } }, "sha512-V/FF8kX8JGSefsVCG1spCLSrHdNR/JFeUMn1jS9KG/Eizjx+evtdKQKLJXFgIylY/bKTXKhc2SYDPIGrIhzsug=="],
+
+    "@supabase/supabase-js": ["@supabase/supabase-js@2.99.2", "", { "dependencies": { "@supabase/auth-js": "2.99.2", "@supabase/functions-js": "2.99.2", "@supabase/postgrest-js": "2.99.2", "@supabase/realtime-js": "2.99.2", "@supabase/storage-js": "2.99.2" } }, "sha512-179rn5wq0wBAqqGwAwR7TUGg2NOaP+fkd5FCVbYJXby85fsRNPFoNJN8YRBepqX2tN7JJcnTjqaAMXuNjiyisA=="],
+
     "@swc/helpers": ["@swc/helpers@0.5.15", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g=="],
 
     "@tailwindcss/node": ["@tailwindcss/node@4.2.1", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "^5.19.0", "jiti": "^2.6.1", "lightningcss": "1.31.1", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.2.1" } }, "sha512-jlx6sLk4EOwO6hHe1oCGm1Q4AN/s0rSrTTPBGPM0/RQ6Uylwq17FuU8IeJJKEjtc6K6O07zsvP+gDO6MMWo7pg=="],
@@ -380,9 +393,13 @@
 
     "@types/node": ["@types/node@22.19.15", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg=="],
 
+    "@types/phoenix": ["@types/phoenix@1.6.7", "", {}, "sha512-oN9ive//QSBkf19rfDv45M7eZPi0eEXylht2OLEXicu5b4KoQ1OzXIw+xDSGWxSxe1JmepRR/ZH283vsu518/Q=="],
+
     "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
+
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.57.1", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.57.1", "@typescript-eslint/type-utils": "8.57.1", "@typescript-eslint/utils": "8.57.1", "@typescript-eslint/visitor-keys": "8.57.1", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.4.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.57.1", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-Gn3aqnvNl4NGc6x3/Bqk1AOn0thyTU9bqDRhiRnUWezgvr2OnhYCWCgC8zXXRVqBsIL1pSDt7T9nJUe0oM0kDQ=="],
 
@@ -721,6 +738,8 @@
     "http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
 
     "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
+    "iceberg-js": ["iceberg-js@0.8.1", "", {}, "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA=="],
 
     "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 

--- a/scorerebound/eslint.config.mjs
+++ b/scorerebound/eslint.config.mjs
@@ -10,7 +10,7 @@ const compat = new FlatCompat({
 });
 
 const eslintConfig = [
-  ...compat.extends("next/core-web-vitals", "next/typescript"),
+  ...compat.extends("next/core-web-vitals"),
 ];
 
 export default eslintConfig;

--- a/scorerebound/package.json
+++ b/scorerebound/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scorerebound",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
@@ -14,6 +14,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@supabase/supabase-js": "^2.99.2",
     "next": "^15.3.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"

--- a/scorerebound/src/lib/database.types.test.ts
+++ b/scorerebound/src/lib/database.types.test.ts
@@ -1,0 +1,330 @@
+import { describe, it, expect } from "vitest";
+import type {
+  Database,
+  LoanType,
+  RecoveryPath,
+  DelinquencyStatus,
+  ScoreRange,
+  EmailSequenceStatus,
+  Profile,
+  QuizResponse,
+  RecoveryPlan,
+  PlanStep,
+  ProgressEntry,
+  AffiliateClick,
+  EmailSequence,
+  QuizResponseInsert,
+  RecoveryPlanInsert,
+  PlanStepInsert,
+  ProgressEntryInsert,
+  AffiliateClickInsert,
+  EmailSequenceInsert,
+  ProfileUpdate,
+  RecoveryPlanJson,
+} from "./database.types";
+
+describe("Database enum types", () => {
+  it("LoanType has all expected values", () => {
+    const values: LoanType[] = [
+      "federal_direct",
+      "federal_ffel",
+      "federal_perkins",
+      "parent_plus",
+      "private",
+    ];
+    expect(values).toHaveLength(5);
+  });
+
+  it("RecoveryPath has all expected values", () => {
+    const values: RecoveryPath[] = [
+      "ibr_enrollment",
+      "rehabilitation",
+      "consolidation",
+      "credit_building",
+      "mixed",
+    ];
+    expect(values).toHaveLength(5);
+  });
+
+  it("DelinquencyStatus has all expected values", () => {
+    const values: DelinquencyStatus[] = [
+      "current",
+      "30_days",
+      "60_days",
+      "90_plus",
+      "default",
+      "collections",
+    ];
+    expect(values).toHaveLength(6);
+  });
+
+  it("ScoreRange has all expected values", () => {
+    const values: ScoreRange[] = [
+      "300_499",
+      "500_579",
+      "580_619",
+      "620_659",
+      "660_699",
+      "700_749",
+      "750_plus",
+    ];
+    expect(values).toHaveLength(7);
+  });
+
+  it("EmailSequenceStatus has all expected values", () => {
+    const values: EmailSequenceStatus[] = [
+      "active",
+      "paused",
+      "completed",
+      "unsubscribed",
+    ];
+    expect(values).toHaveLength(4);
+  });
+});
+
+describe("Database row types", () => {
+  it("Profile type matches schema", () => {
+    const profile: Profile = {
+      id: "00000000-0000-0000-0000-000000000001",
+      display_name: "Test User",
+      score_range: "500_579",
+      notification_prefs: { email: true, push: false },
+      is_anonymous: false,
+      created_at: "2026-03-16T00:00:00Z",
+      updated_at: "2026-03-16T00:00:00Z",
+    };
+    expect(profile.id).toBeDefined();
+    expect(profile.notification_prefs.email).toBe(true);
+    expect(profile.is_anonymous).toBe(false);
+  });
+
+  it("Profile allows null display_name and score_range", () => {
+    const profile: Profile = {
+      id: "00000000-0000-0000-0000-000000000001",
+      display_name: null,
+      score_range: null,
+      notification_prefs: { email: true, push: false },
+      is_anonymous: true,
+      created_at: "2026-03-16T00:00:00Z",
+      updated_at: "2026-03-16T00:00:00Z",
+    };
+    expect(profile.display_name).toBeNull();
+    expect(profile.score_range).toBeNull();
+  });
+
+  it("QuizResponse type matches schema with nullable user_id", () => {
+    const response: QuizResponse = {
+      id: "10000000-0000-0000-0000-000000000001",
+      user_id: null,
+      loan_type: "federal_direct",
+      servicer: "MOHELA",
+      delinquency_status: "90_plus",
+      current_score_range: "500_579",
+      goals: ["improve_credit_score", "get_out_of_default"],
+      created_at: "2026-03-16T00:00:00Z",
+    };
+    expect(response.user_id).toBeNull();
+    expect(response.goals).toHaveLength(2);
+  });
+
+  it("RecoveryPlan type matches schema with typed plan_json", () => {
+    const planJson: RecoveryPlanJson = {
+      title: "Recovery Plan",
+      summary: "Test summary",
+      steps_overview: ["Step 1", "Step 2"],
+      estimated_score_improvement: "80-120 points",
+      warnings: ["Warning 1"],
+    };
+    const plan: RecoveryPlan = {
+      id: "20000000-0000-0000-0000-000000000001",
+      quiz_response_id: "10000000-0000-0000-0000-000000000001",
+      user_id: "00000000-0000-0000-0000-000000000001",
+      plan_json: planJson,
+      recovery_path: "rehabilitation",
+      estimated_months: 12,
+      created_at: "2026-03-16T00:00:00Z",
+    };
+    expect(plan.plan_json.title).toBe("Recovery Plan");
+    expect(plan.estimated_months).toBe(12);
+  });
+
+  it("PlanStep type matches schema with completion tracking", () => {
+    const step: PlanStep = {
+      id: "30000000-0000-0000-0000-000000000001",
+      plan_id: "20000000-0000-0000-0000-000000000001",
+      step_order: 1,
+      title: "Contact Servicer",
+      description: "Call your loan servicer",
+      action_url: "https://example.com",
+      is_completed: true,
+      completed_at: "2026-03-16T00:00:00Z",
+      created_at: "2026-03-16T00:00:00Z",
+    };
+    expect(step.is_completed).toBe(true);
+    expect(step.completed_at).toBeDefined();
+  });
+
+  it("ProgressEntry enforces user_id (not nullable)", () => {
+    const entry: ProgressEntry = {
+      id: "40000000-0000-0000-0000-000000000001",
+      user_id: "00000000-0000-0000-0000-000000000001",
+      plan_id: "20000000-0000-0000-0000-000000000001",
+      action_type: "score_check",
+      action_description: "Monthly credit score check",
+      score_snapshot: 520,
+      completed_at: "2026-03-16T00:00:00Z",
+    };
+    expect(entry.user_id).toBeDefined();
+    expect(entry.score_snapshot).toBe(520);
+  });
+
+  it("AffiliateClick allows nullable user_id for anonymous tracking", () => {
+    const click: AffiliateClick = {
+      id: "50000000-0000-0000-0000-000000000001",
+      user_id: null,
+      product_slug: "self-credit-builder",
+      affiliate_url: "https://www.self.inc/refer/scorerebound",
+      referrer_page: "/recovery-plan",
+      clicked_at: "2026-03-16T00:00:00Z",
+    };
+    expect(click.user_id).toBeNull();
+    expect(click.product_slug).toBe("self-credit-builder");
+  });
+
+  it("EmailSequence type matches schema with drip campaign state", () => {
+    const seq: EmailSequence = {
+      id: "60000000-0000-0000-0000-000000000001",
+      user_id: "00000000-0000-0000-0000-000000000001",
+      sequence_name: "rehabilitation_drip",
+      current_step: 3,
+      status: "active",
+      last_sent_at: "2026-03-13T00:00:00Z",
+      next_send_at: "2026-03-20T00:00:00Z",
+      metadata: { recovery_path: "rehabilitation" },
+      created_at: "2026-03-16T00:00:00Z",
+      updated_at: "2026-03-16T00:00:00Z",
+    };
+    expect(seq.status).toBe("active");
+    expect(seq.current_step).toBe(3);
+  });
+});
+
+describe("Insert types", () => {
+  it("QuizResponseInsert allows omitting auto-generated fields", () => {
+    const insert: QuizResponseInsert = {
+      user_id: null,
+      loan_type: "federal_direct",
+      servicer: "MOHELA",
+      delinquency_status: "90_plus",
+      current_score_range: "500_579",
+      goals: ["improve_credit_score"],
+    };
+    expect(insert.loan_type).toBe("federal_direct");
+    // id and created_at should be optional
+    expect("id" in insert).toBe(false);
+  });
+
+  it("RecoveryPlanInsert requires quiz_response_id", () => {
+    const insert: RecoveryPlanInsert = {
+      quiz_response_id: "10000000-0000-0000-0000-000000000001",
+      user_id: null,
+      plan_json: {
+        title: "Test",
+        summary: "Test",
+        steps_overview: [],
+        estimated_score_improvement: "50 points",
+        warnings: [],
+      },
+      recovery_path: "consolidation",
+      estimated_months: 6,
+    };
+    expect(insert.quiz_response_id).toBeDefined();
+  });
+
+  it("PlanStepInsert requires plan_id, step_order, title, description", () => {
+    const insert: PlanStepInsert = {
+      plan_id: "20000000-0000-0000-0000-000000000001",
+      step_order: 1,
+      title: "Step 1",
+      description: "Do this first",
+      action_url: null,
+    };
+    expect(insert.plan_id).toBeDefined();
+    expect(insert.step_order).toBe(1);
+  });
+
+  it("ProgressEntryInsert requires user_id and plan_id", () => {
+    const insert: ProgressEntryInsert = {
+      user_id: "00000000-0000-0000-0000-000000000001",
+      plan_id: "20000000-0000-0000-0000-000000000001",
+      action_type: "milestone",
+      action_description: "Completed step 1",
+      score_snapshot: null,
+    };
+    expect(insert.user_id).toBeDefined();
+  });
+
+  it("AffiliateClickInsert requires product_slug and affiliate_url", () => {
+    const insert: AffiliateClickInsert = {
+      user_id: null,
+      product_slug: "discover-secured",
+      affiliate_url: "https://discover.com",
+      referrer_page: "/paths",
+    };
+    expect(insert.product_slug).toBe("discover-secured");
+  });
+
+  it("EmailSequenceInsert requires user_id and sequence_name", () => {
+    const insert: EmailSequenceInsert = {
+      user_id: "00000000-0000-0000-0000-000000000001",
+      sequence_name: "welcome_drip",
+    };
+    expect(insert.sequence_name).toBe("welcome_drip");
+    // status, current_step, metadata should default
+    expect("status" in insert).toBe(false);
+  });
+});
+
+describe("Update types", () => {
+  it("ProfileUpdate allows partial updates", () => {
+    const update: ProfileUpdate = {
+      display_name: "New Name",
+    };
+    expect(update.display_name).toBe("New Name");
+    // Other fields should be optional
+    expect("score_range" in update).toBe(false);
+  });
+});
+
+describe("Database type structure", () => {
+  it("Database type has public schema with all tables", () => {
+    // Type-level check: ensure Database has the expected structure
+    type Tables = Database["public"]["Tables"];
+    type TableNames = keyof Tables;
+
+    const expectedTables: TableNames[] = [
+      "profiles",
+      "quiz_responses",
+      "recovery_plans",
+      "plan_steps",
+      "progress_entries",
+      "affiliate_clicks",
+      "email_sequences",
+    ];
+    expect(expectedTables).toHaveLength(7);
+  });
+
+  it("Database type has all enum definitions", () => {
+    type Enums = Database["public"]["Enums"];
+    type EnumNames = keyof Enums;
+
+    const expectedEnums: EnumNames[] = [
+      "loan_type",
+      "recovery_path",
+      "delinquency_status",
+      "score_range",
+      "email_sequence_status",
+    ];
+    expect(expectedEnums).toHaveLength(5);
+  });
+});

--- a/scorerebound/src/lib/database.types.ts
+++ b/scorerebound/src/lib/database.types.ts
@@ -1,0 +1,276 @@
+/**
+ * TypeScript types for the ScoreRebound Supabase database schema.
+ *
+ * These types mirror the SQL schema defined in supabase/migrations/.
+ * Regenerate from a running Supabase instance with:
+ *   bunx supabase gen types typescript --local > src/lib/database.types.ts
+ */
+
+// ============================================================================
+// Enum types
+// ============================================================================
+
+export type LoanType =
+  | "federal_direct"
+  | "federal_ffel"
+  | "federal_perkins"
+  | "parent_plus"
+  | "private";
+
+export type RecoveryPath =
+  | "ibr_enrollment"
+  | "rehabilitation"
+  | "consolidation"
+  | "credit_building"
+  | "mixed";
+
+export type DelinquencyStatus =
+  | "current"
+  | "30_days"
+  | "60_days"
+  | "90_plus"
+  | "default"
+  | "collections";
+
+export type ScoreRange =
+  | "300_499"
+  | "500_579"
+  | "580_619"
+  | "620_659"
+  | "660_699"
+  | "700_749"
+  | "750_plus";
+
+export type EmailSequenceStatus =
+  | "active"
+  | "paused"
+  | "completed"
+  | "unsubscribed";
+
+// ============================================================================
+// Table row types
+// ============================================================================
+
+export interface Profile {
+  id: string;
+  display_name: string | null;
+  score_range: ScoreRange | null;
+  notification_prefs: { email: boolean; push: boolean };
+  is_anonymous: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface QuizResponse {
+  id: string;
+  user_id: string | null;
+  loan_type: LoanType;
+  servicer: string;
+  delinquency_status: DelinquencyStatus;
+  current_score_range: ScoreRange;
+  goals: string[];
+  created_at: string;
+}
+
+export interface RecoveryPlan {
+  id: string;
+  quiz_response_id: string;
+  user_id: string | null;
+  plan_json: RecoveryPlanJson;
+  recovery_path: RecoveryPath;
+  estimated_months: number;
+  created_at: string;
+}
+
+export interface RecoveryPlanJson {
+  title: string;
+  summary: string;
+  steps_overview: string[];
+  estimated_score_improvement: string;
+  warnings: string[];
+}
+
+export interface PlanStep {
+  id: string;
+  plan_id: string;
+  step_order: number;
+  title: string;
+  description: string;
+  action_url: string | null;
+  is_completed: boolean;
+  completed_at: string | null;
+  created_at: string;
+}
+
+export interface ProgressEntry {
+  id: string;
+  user_id: string;
+  plan_id: string;
+  action_type: string;
+  action_description: string | null;
+  score_snapshot: number | null;
+  completed_at: string;
+}
+
+export interface AffiliateClick {
+  id: string;
+  user_id: string | null;
+  product_slug: string;
+  affiliate_url: string;
+  referrer_page: string | null;
+  clicked_at: string;
+}
+
+export interface EmailSequence {
+  id: string;
+  user_id: string;
+  sequence_name: string;
+  current_step: number;
+  status: EmailSequenceStatus;
+  last_sent_at: string | null;
+  next_send_at: string | null;
+  metadata: Record<string, unknown>;
+  created_at: string;
+  updated_at: string;
+}
+
+// ============================================================================
+// Insert types (omit auto-generated fields)
+// ============================================================================
+
+export type ProfileInsert = Omit<Profile, "created_at" | "updated_at"> & {
+  created_at?: string;
+  updated_at?: string;
+};
+
+export type QuizResponseInsert = Omit<QuizResponse, "id" | "created_at"> & {
+  id?: string;
+  created_at?: string;
+};
+
+export type RecoveryPlanInsert = Omit<RecoveryPlan, "id" | "created_at"> & {
+  id?: string;
+  created_at?: string;
+};
+
+export type PlanStepInsert = Omit<
+  PlanStep,
+  "id" | "is_completed" | "completed_at" | "created_at"
+> & {
+  id?: string;
+  is_completed?: boolean;
+  completed_at?: string | null;
+  created_at?: string;
+};
+
+export type ProgressEntryInsert = Omit<
+  ProgressEntry,
+  "id" | "completed_at"
+> & {
+  id?: string;
+  completed_at?: string;
+};
+
+export type AffiliateClickInsert = Omit<
+  AffiliateClick,
+  "id" | "clicked_at"
+> & {
+  id?: string;
+  clicked_at?: string;
+};
+
+export type EmailSequenceInsert = Omit<
+  EmailSequence,
+  | "id"
+  | "current_step"
+  | "status"
+  | "last_sent_at"
+  | "next_send_at"
+  | "metadata"
+  | "created_at"
+  | "updated_at"
+> & {
+  id?: string;
+  current_step?: number;
+  status?: EmailSequenceStatus;
+  last_sent_at?: string | null;
+  next_send_at?: string | null;
+  metadata?: Record<string, unknown>;
+  created_at?: string;
+  updated_at?: string;
+};
+
+// ============================================================================
+// Update types (all fields optional except id)
+// ============================================================================
+
+export type ProfileUpdate = Partial<Omit<Profile, "id" | "created_at">>;
+
+export type QuizResponseUpdate = Partial<Omit<QuizResponse, "id" | "created_at">>;
+
+export type RecoveryPlanUpdate = Partial<Omit<RecoveryPlan, "id" | "created_at">>;
+
+export type PlanStepUpdate = Partial<Omit<PlanStep, "id" | "created_at">>;
+
+export type ProgressEntryUpdate = Partial<Omit<ProgressEntry, "id">>;
+
+export type AffiliateClickUpdate = Partial<Omit<AffiliateClick, "id">>;
+
+export type EmailSequenceUpdate = Partial<
+  Omit<EmailSequence, "id" | "created_at">
+>;
+
+// ============================================================================
+// Supabase Database type (compatible with @supabase/supabase-js generics)
+// ============================================================================
+
+export interface Database {
+  public: {
+    Tables: {
+      profiles: {
+        Row: Profile;
+        Insert: ProfileInsert;
+        Update: ProfileUpdate;
+      };
+      quiz_responses: {
+        Row: QuizResponse;
+        Insert: QuizResponseInsert;
+        Update: QuizResponseUpdate;
+      };
+      recovery_plans: {
+        Row: RecoveryPlan;
+        Insert: RecoveryPlanInsert;
+        Update: RecoveryPlanUpdate;
+      };
+      plan_steps: {
+        Row: PlanStep;
+        Insert: PlanStepInsert;
+        Update: PlanStepUpdate;
+      };
+      progress_entries: {
+        Row: ProgressEntry;
+        Insert: ProgressEntryInsert;
+        Update: ProgressEntryUpdate;
+      };
+      affiliate_clicks: {
+        Row: AffiliateClick;
+        Insert: AffiliateClickInsert;
+        Update: AffiliateClickUpdate;
+      };
+      email_sequences: {
+        Row: EmailSequence;
+        Insert: EmailSequenceInsert;
+        Update: EmailSequenceUpdate;
+      };
+    };
+    Views: Record<string, never>;
+    Functions: Record<string, never>;
+    Enums: {
+      loan_type: LoanType;
+      recovery_path: RecoveryPath;
+      delinquency_status: DelinquencyStatus;
+      score_range: ScoreRange;
+      email_sequence_status: EmailSequenceStatus;
+    };
+  };
+}

--- a/scorerebound/src/lib/supabase.ts
+++ b/scorerebound/src/lib/supabase.ts
@@ -1,0 +1,41 @@
+import { createClient } from "@supabase/supabase-js";
+import type { Database } from "./database.types";
+
+function getSupabaseUrl(): string {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  if (!url) throw new Error("NEXT_PUBLIC_SUPABASE_URL is not set");
+  return url;
+}
+
+function getSupabaseAnonKey(): string {
+  const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  if (!key) throw new Error("NEXT_PUBLIC_SUPABASE_ANON_KEY is not set");
+  return key;
+}
+
+/**
+ * Supabase client for use in browser/client components.
+ * Uses the anon key — all queries are subject to RLS policies.
+ *
+ * Lazily initialized to avoid crashing at import time when env vars
+ * are not yet available (e.g., during build or test).
+ */
+export function getSupabaseClient() {
+  return createClient<Database>(getSupabaseUrl(), getSupabaseAnonKey());
+}
+
+/**
+ * Create a Supabase client with a custom access token (e.g., from server-side auth).
+ * Useful in API routes and Server Components where you have the user's JWT.
+ *
+ * @remarks Server-side only — do not import in client components.
+ */
+export function createServerSupabaseClient(accessToken?: string) {
+  return createClient<Database>(getSupabaseUrl(), getSupabaseAnonKey(), {
+    global: {
+      headers: accessToken
+        ? { Authorization: `Bearer ${accessToken}` }
+        : undefined,
+    },
+  });
+}

--- a/scorerebound/supabase/.gitignore
+++ b/scorerebound/supabase/.gitignore
@@ -1,0 +1,8 @@
+# Supabase
+.branches
+.temp
+
+# dotenvx
+.env.keys
+.env.local
+.env.*.local

--- a/scorerebound/supabase/config.toml
+++ b/scorerebound/supabase/config.toml
@@ -1,0 +1,357 @@
+# For detailed configuration reference documentation, visit:
+# https://supabase.com/docs/guides/local-development/cli/config
+# A string used to distinguish different Supabase projects on the same host. Defaults to the
+# working directory name when running `supabase init`.
+project_id = "scorerebound"
+
+[api]
+enabled = true
+# Port to use for the API URL.
+port = 54321
+# Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
+# endpoints. `public` and `graphql_public` schemas are included by default.
+schemas = ["public", "graphql_public"]
+# Extra schemas to add to the search_path of every request.
+extra_search_path = ["public", "extensions"]
+# The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
+# for accidental or malicious requests.
+max_rows = 1000
+
+[api.tls]
+# Enable HTTPS endpoints locally using a self-signed certificate.
+enabled = false
+# Paths to self-signed certificate pair.
+# cert_path = "../certs/my-cert.pem"
+# key_path = "../certs/my-key.pem"
+
+[db]
+# Port to use for the local database URL.
+port = 54322
+# Port used by db diff command to initialize the shadow database.
+shadow_port = 54320
+# The database major version to use. This has to be the same as your remote database's. Run `SHOW
+# server_version;` on the remote database to check.
+major_version = 17
+
+[db.pooler]
+enabled = false
+# Port to use for the local connection pooler.
+port = 54329
+# Specifies when a server connection can be reused by other clients.
+# Configure one of the supported pooler modes: `transaction`, `session`.
+pool_mode = "transaction"
+# How many server connections to allow per user/database pair.
+default_pool_size = 20
+# Maximum number of client connections allowed.
+max_client_conn = 100
+
+# [db.vault]
+# secret_key = "env(SECRET_VALUE)"
+
+[db.migrations]
+# If disabled, migrations will be skipped during a db push or reset.
+enabled = true
+# Specifies an ordered list of schema files that describe your database.
+# Supports glob patterns relative to supabase directory: "./schemas/*.sql"
+schema_paths = []
+
+[db.seed]
+# If enabled, seeds the database after migrations during a db reset.
+enabled = true
+# Specifies an ordered list of seed files to load during db reset.
+# Supports glob patterns relative to supabase directory: "./seeds/*.sql"
+sql_paths = ["./seed.sql"]
+
+[db.network_restrictions]
+# Enable management of network restrictions.
+enabled = false
+# List of IPv4 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv4 connections. Set empty array to block all IPs.
+allowed_cidrs = ["0.0.0.0/0"]
+# List of IPv6 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv6 connections. Set empty array to block all IPs.
+allowed_cidrs_v6 = ["::/0"]
+
+[realtime]
+enabled = true
+# Bind realtime via either IPv4 or IPv6. (default: IPv4)
+# ip_version = "IPv6"
+# The maximum length in bytes of HTTP request headers. (default: 4096)
+# max_header_length = 4096
+
+[studio]
+enabled = true
+# Port to use for Supabase Studio.
+port = 54323
+# External URL of the API server that frontend connects to.
+api_url = "http://127.0.0.1"
+# OpenAI API Key to use for Supabase AI in the Supabase Studio.
+openai_api_key = "env(OPENAI_API_KEY)"
+
+# Email testing server. Emails sent with the local dev setup are not actually sent - rather, they
+# are monitored, and you can view the emails that would have been sent from the web interface.
+[inbucket]
+enabled = true
+# Port to use for the email testing server web interface.
+port = 54324
+# Uncomment to expose additional ports for testing user applications that send emails.
+# smtp_port = 54325
+# pop3_port = 54326
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+[storage]
+enabled = true
+# The maximum file size allowed (e.g. "5MB", "500KB").
+file_size_limit = "50MiB"
+
+# Image transformation API is available to Supabase Pro plan.
+# [storage.image_transformation]
+# enabled = true
+
+# Uncomment to configure local storage buckets
+# [storage.buckets.images]
+# public = false
+# file_size_limit = "50MiB"
+# allowed_mime_types = ["image/png", "image/jpeg"]
+# objects_path = "./images"
+
+[auth]
+enabled = true
+# The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
+# in emails.
+site_url = "http://127.0.0.1:3000"
+# A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
+additional_redirect_urls = ["https://127.0.0.1:3000"]
+# How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
+jwt_expiry = 3600
+# JWT issuer URL. If not set, defaults to the local API URL (http://127.0.0.1:<port>/auth/v1).
+# jwt_issuer = ""
+# Path to JWT signing key. DO NOT commit your signing keys file to git.
+# signing_keys_path = "./signing_keys.json"
+# If disabled, the refresh token will never expire.
+enable_refresh_token_rotation = true
+# Allows refresh tokens to be reused after expiry, up to the specified interval in seconds.
+# Requires enable_refresh_token_rotation = true.
+refresh_token_reuse_interval = 10
+# Allow/disallow new user signups to your project.
+enable_signup = true
+# Allow/disallow anonymous sign-ins to your project.
+enable_anonymous_sign_ins = true
+# Allow/disallow testing manual linking of accounts
+enable_manual_linking = false
+# Passwords shorter than this value will be rejected as weak. Minimum 6, recommended 8 or more.
+minimum_password_length = 6
+# Passwords that do not meet the following requirements will be rejected as weak. Supported values
+# are: `letters_digits`, `lower_upper_letters_digits`, `lower_upper_letters_digits_symbols`
+password_requirements = ""
+
+[auth.rate_limit]
+# Number of emails that can be sent per hour. Requires auth.email.smtp to be enabled.
+email_sent = 2
+# Number of SMS messages that can be sent per hour. Requires auth.sms to be enabled.
+sms_sent = 30
+# Number of anonymous sign-ins that can be made per hour per IP address. Requires enable_anonymous_sign_ins = true.
+anonymous_users = 30
+# Number of sessions that can be refreshed in a 5 minute interval per IP address.
+token_refresh = 150
+# Number of sign up and sign-in requests that can be made in a 5 minute interval per IP address (excludes anonymous users).
+sign_in_sign_ups = 30
+# Number of OTP / Magic link verifications that can be made in a 5 minute interval per IP address.
+token_verifications = 30
+# Number of Web3 logins that can be made in a 5 minute interval per IP address.
+web3 = 30
+
+# Configure one of the supported captcha providers: `hcaptcha`, `turnstile`.
+# [auth.captcha]
+# enabled = true
+# provider = "hcaptcha"
+# secret = ""
+
+[auth.email]
+# Allow/disallow new user signups via email to your project.
+enable_signup = true
+# If enabled, a user will be required to confirm any email change on both the old, and new email
+# addresses. If disabled, only the new email is required to confirm.
+double_confirm_changes = true
+# If enabled, users need to confirm their email address before signing in.
+enable_confirmations = false
+# If enabled, users will need to reauthenticate or have logged in recently to change their password.
+secure_password_change = false
+# Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.
+max_frequency = "1s"
+# Number of characters used in the email OTP.
+otp_length = 6
+# Number of seconds before the email OTP expires (defaults to 1 hour).
+otp_expiry = 3600
+
+# Use a production-ready SMTP server
+# [auth.email.smtp]
+# enabled = true
+# host = "smtp.sendgrid.net"
+# port = 587
+# user = "apikey"
+# pass = "env(SENDGRID_API_KEY)"
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+# Uncomment to customize email template
+# [auth.email.template.invite]
+# subject = "You have been invited"
+# content_path = "./supabase/templates/invite.html"
+
+# Uncomment to customize notification email template
+# [auth.email.notification.password_changed]
+# enabled = true
+# subject = "Your password has been changed"
+# content_path = "./templates/password_changed_notification.html"
+
+[auth.sms]
+# Allow/disallow new user signups via SMS to your project.
+enable_signup = false
+# If enabled, users need to confirm their phone number before signing in.
+enable_confirmations = false
+# Template for sending OTP to users
+template = "Your code is {{ .Code }}"
+# Controls the minimum amount of time that must pass before sending another sms otp.
+max_frequency = "5s"
+
+# Use pre-defined map of phone number to OTP for testing.
+# [auth.sms.test_otp]
+# 4152127777 = "123456"
+
+# Configure logged in session timeouts.
+# [auth.sessions]
+# Force log out after the specified duration.
+# timebox = "24h"
+# Force log out if the user has been inactive longer than the specified duration.
+# inactivity_timeout = "8h"
+
+# This hook runs before a new user is created and allows developers to reject the request based on the incoming user object.
+# [auth.hook.before_user_created]
+# enabled = true
+# uri = "pg-functions://postgres/auth/before-user-created-hook"
+
+# This hook runs before a token is issued and allows you to add additional claims based on the authentication method used.
+# [auth.hook.custom_access_token]
+# enabled = true
+# uri = "pg-functions://<database>/<schema>/<hook_name>"
+
+# Configure one of the supported SMS providers: `twilio`, `twilio_verify`, `messagebird`, `textlocal`, `vonage`.
+[auth.sms.twilio]
+enabled = false
+account_sid = ""
+message_service_sid = ""
+# DO NOT commit your Twilio auth token to git. Use environment variable substitution instead:
+auth_token = "env(SUPABASE_AUTH_SMS_TWILIO_AUTH_TOKEN)"
+
+# Multi-factor-authentication is available to Supabase Pro plan.
+[auth.mfa]
+# Control how many MFA factors can be enrolled at once per user.
+max_enrolled_factors = 10
+
+# Control MFA via App Authenticator (TOTP)
+[auth.mfa.totp]
+enroll_enabled = false
+verify_enabled = false
+
+# Configure MFA via Phone Messaging
+[auth.mfa.phone]
+enroll_enabled = false
+verify_enabled = false
+otp_length = 6
+template = "Your code is {{ .Code }}"
+max_frequency = "5s"
+
+# Configure MFA via WebAuthn
+# [auth.mfa.web_authn]
+# enroll_enabled = true
+# verify_enabled = true
+
+# Use an external OAuth provider. The full list of providers are: `apple`, `azure`, `bitbucket`,
+# `discord`, `facebook`, `github`, `gitlab`, `google`, `keycloak`, `linkedin_oidc`, `notion`, `twitch`,
+# `twitter`, `slack`, `spotify`, `workos`, `zoom`.
+[auth.external.apple]
+enabled = false
+client_id = ""
+# DO NOT commit your OAuth provider secret to git. Use environment variable substitution instead:
+secret = "env(SUPABASE_AUTH_EXTERNAL_APPLE_SECRET)"
+# Overrides the default auth redirectUrl.
+redirect_uri = ""
+# Overrides the default auth provider URL. Used to support self-hosted gitlab, single-tenant Azure,
+# or any other third-party OIDC providers.
+url = ""
+# If enabled, the nonce check will be skipped. Required for local sign in with Google auth.
+skip_nonce_check = false
+# If enabled, it will allow the user to successfully authenticate when the provider does not return an email address.
+email_optional = false
+
+# Allow Solana wallet holders to sign in to your project via the Sign in with Solana (SIWS, EIP-4361) standard.
+# You can configure "web3" rate limit in the [auth.rate_limit] section and set up [auth.captcha] if self-hosting.
+[auth.web3.solana]
+enabled = false
+
+# Use Firebase Auth as a third-party provider alongside Supabase Auth.
+[auth.third_party.firebase]
+enabled = false
+# project_id = "my-firebase-project"
+
+# Use Auth0 as a third-party provider alongside Supabase Auth.
+[auth.third_party.auth0]
+enabled = false
+# tenant = "my-auth0-tenant"
+# tenant_region = "us"
+
+# Use AWS Cognito (Amplify) as a third-party provider alongside Supabase Auth.
+[auth.third_party.aws_cognito]
+enabled = false
+# user_pool_id = "my-user-pool-id"
+# user_pool_region = "us-east-1"
+
+# Use Clerk as a third-party provider alongside Supabase Auth.
+[auth.third_party.clerk]
+enabled = false
+# Obtain from https://clerk.com/setup/supabase
+# domain = "example.clerk.accounts.dev"
+
+# OAuth server configuration
+[auth.oauth_server]
+# Enable OAuth server functionality
+enabled = false
+# Path for OAuth consent flow UI
+authorization_url_path = "/oauth/consent"
+# Allow dynamic client registration
+allow_dynamic_registration = false
+
+[edge_runtime]
+enabled = true
+# Supported request policies: `oneshot`, `per_worker`.
+# `per_worker` (default) — enables hot reload during local development.
+# `oneshot` — fallback mode if hot reload causes issues (e.g. in large repos or with symlinks).
+policy = "per_worker"
+# Port to attach the Chrome inspector for debugging edge functions.
+inspector_port = 8083
+# The Deno major version to use.
+deno_version = 2
+
+# [edge_runtime.secrets]
+# secret_key = "env(SECRET_VALUE)"
+
+[analytics]
+enabled = true
+port = 54327
+# Configure one of the supported backends: `postgres`, `bigquery`.
+backend = "postgres"
+
+# Experimental features may be deprecated any time
+[experimental]
+# Configures Postgres storage engine to use OrioleDB (S3)
+orioledb_version = ""
+# Configures S3 bucket URL, eg. <bucket_name>.s3-<region>.amazonaws.com
+s3_host = "env(S3_HOST)"
+# Configures S3 bucket region, eg. us-east-1
+s3_region = "env(S3_REGION)"
+# Configures AWS_ACCESS_KEY_ID for S3 bucket
+s3_access_key = "env(S3_ACCESS_KEY)"
+# Configures AWS_SECRET_ACCESS_KEY for S3 bucket
+s3_secret_key = "env(S3_SECRET_KEY)"

--- a/scorerebound/supabase/migrations/20260316000001_create_profiles.sql
+++ b/scorerebound/supabase/migrations/20260316000001_create_profiles.sql
@@ -1,0 +1,107 @@
+-- Migration: Create custom enums and profiles table
+-- Profiles extend Supabase Auth users with app-specific data
+
+-- Custom enum types used across the schema
+CREATE TYPE loan_type AS ENUM (
+  'federal_direct',
+  'federal_ffel',
+  'federal_perkins',
+  'parent_plus',
+  'private'
+);
+
+CREATE TYPE recovery_path AS ENUM (
+  'ibr_enrollment',
+  'rehabilitation',
+  'consolidation',
+  'credit_building',
+  'mixed'
+);
+
+CREATE TYPE delinquency_status AS ENUM (
+  'current',
+  '30_days',
+  '60_days',
+  '90_plus',
+  'default',
+  'collections'
+);
+
+CREATE TYPE score_range AS ENUM (
+  '300_499',
+  '500_579',
+  '580_619',
+  '620_659',
+  '660_699',
+  '700_749',
+  '750_plus'
+);
+
+CREATE TYPE email_sequence_status AS ENUM (
+  'active',
+  'paused',
+  'completed',
+  'unsubscribed'
+);
+
+-- Profiles table: extends auth.users with ScoreRebound-specific data
+CREATE TABLE profiles (
+  id uuid PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  display_name text,
+  score_range score_range,
+  notification_prefs jsonb NOT NULL DEFAULT '{"email": true, "push": false}'::jsonb,
+  is_anonymous boolean NOT NULL DEFAULT false,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- Index on created_at for sorting
+CREATE INDEX idx_profiles_created_at ON profiles (created_at);
+
+-- Auto-update updated_at on row change
+CREATE OR REPLACE FUNCTION update_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER profiles_updated_at
+  BEFORE UPDATE ON profiles
+  FOR EACH ROW
+  EXECUTE FUNCTION update_updated_at();
+
+-- Auto-create profile when a new user signs up via auth
+CREATE OR REPLACE FUNCTION handle_new_user()
+RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO public.profiles (id, is_anonymous)
+  VALUES (
+    NEW.id,
+    COALESCE(NEW.is_anonymous, false)
+  );
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+CREATE TRIGGER on_auth_user_created
+  AFTER INSERT ON auth.users
+  FOR EACH ROW
+  EXECUTE FUNCTION handle_new_user();
+
+-- RLS: user-owns-row pattern
+ALTER TABLE profiles ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view own profile"
+  ON profiles FOR SELECT
+  USING (auth.uid() = id);
+
+CREATE POLICY "Users can insert own profile"
+  ON profiles FOR INSERT
+  WITH CHECK (auth.uid() = id);
+
+CREATE POLICY "Users can update own profile"
+  ON profiles FOR UPDATE
+  USING (auth.uid() = id)
+  WITH CHECK (auth.uid() = id);

--- a/scorerebound/supabase/migrations/20260316000002_create_quiz_responses.sql
+++ b/scorerebound/supabase/migrations/20260316000002_create_quiz_responses.sql
@@ -1,0 +1,43 @@
+-- Migration: Create quiz_responses table
+-- Stores the 5-question quiz answers: loan_type, servicer, delinquency_status, current_score_range, goals
+
+CREATE TABLE quiz_responses (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  loan_type loan_type NOT NULL,
+  servicer text NOT NULL,
+  delinquency_status delinquency_status NOT NULL,
+  current_score_range score_range NOT NULL,
+  goals text[] NOT NULL DEFAULT '{}',
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- Indexes for common queries
+CREATE INDEX idx_quiz_responses_user_id ON quiz_responses (user_id);
+CREATE INDEX idx_quiz_responses_created_at ON quiz_responses (created_at);
+
+-- RLS: authenticated users see own rows, anon role can insert
+ALTER TABLE quiz_responses ENABLE ROW LEVEL SECURITY;
+
+-- Authenticated users can read their own responses
+CREATE POLICY "Users can view own quiz responses"
+  ON quiz_responses FOR SELECT
+  USING (auth.uid() = user_id);
+
+-- Authenticated users can insert with their user_id
+CREATE POLICY "Authenticated users can create quiz responses"
+  ON quiz_responses FOR INSERT
+  TO authenticated
+  WITH CHECK (user_id IS NULL OR auth.uid() = user_id);
+
+-- Anonymous (unauthenticated) users can insert with null user_id
+CREATE POLICY "Anonymous users can create quiz responses"
+  ON quiz_responses FOR INSERT
+  TO anon
+  WITH CHECK (user_id IS NULL);
+
+-- Users can update their own responses (e.g., to claim anonymous responses after signup)
+CREATE POLICY "Users can update own quiz responses"
+  ON quiz_responses FOR UPDATE
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);

--- a/scorerebound/supabase/migrations/20260316000003_create_recovery_plans.sql
+++ b/scorerebound/supabase/migrations/20260316000003_create_recovery_plans.sql
@@ -1,0 +1,43 @@
+-- Migration: Create recovery_plans table
+-- Generated recovery plans linked to quiz responses
+
+CREATE TABLE recovery_plans (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  quiz_response_id uuid NOT NULL REFERENCES quiz_responses(id) ON DELETE CASCADE,
+  user_id uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  plan_json jsonb NOT NULL,
+  recovery_path recovery_path NOT NULL,
+  estimated_months integer NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- Indexes for common queries
+CREATE INDEX idx_recovery_plans_user_id ON recovery_plans (user_id);
+CREATE INDEX idx_recovery_plans_quiz_response_id ON recovery_plans (quiz_response_id);
+CREATE INDEX idx_recovery_plans_created_at ON recovery_plans (created_at);
+
+-- RLS: authenticated users see own rows, anon role can insert
+ALTER TABLE recovery_plans ENABLE ROW LEVEL SECURITY;
+
+-- Authenticated users can read their own plans
+CREATE POLICY "Users can view own recovery plans"
+  ON recovery_plans FOR SELECT
+  USING (auth.uid() = user_id);
+
+-- Authenticated users can insert with their user_id
+CREATE POLICY "Authenticated users can create recovery plans"
+  ON recovery_plans FOR INSERT
+  TO authenticated
+  WITH CHECK (user_id IS NULL OR auth.uid() = user_id);
+
+-- Anonymous (unauthenticated) users can insert with null user_id
+CREATE POLICY "Anonymous users can create recovery plans"
+  ON recovery_plans FOR INSERT
+  TO anon
+  WITH CHECK (user_id IS NULL);
+
+-- Users can update their own plans (e.g., to claim after signup)
+CREATE POLICY "Users can update own recovery plans"
+  ON recovery_plans FOR UPDATE
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);

--- a/scorerebound/supabase/migrations/20260316000004_create_plan_steps.sql
+++ b/scorerebound/supabase/migrations/20260316000004_create_plan_steps.sql
@@ -1,0 +1,73 @@
+-- Migration: Create plan_steps table
+-- Individual actionable steps within a recovery plan with completion tracking
+
+CREATE TABLE plan_steps (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  plan_id uuid NOT NULL REFERENCES recovery_plans(id) ON DELETE CASCADE,
+  step_order integer NOT NULL,
+  title text NOT NULL,
+  description text NOT NULL,
+  action_url text,
+  is_completed boolean NOT NULL DEFAULT false,
+  completed_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- Indexes for common queries
+CREATE INDEX idx_plan_steps_plan_id ON plan_steps (plan_id);
+CREATE INDEX idx_plan_steps_plan_id_order ON plan_steps (plan_id, step_order);
+
+-- RLS: access through parent recovery_plan ownership
+ALTER TABLE plan_steps ENABLE ROW LEVEL SECURITY;
+
+-- Users can view steps for plans they own
+CREATE POLICY "Users can view own plan steps"
+  ON plan_steps FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1 FROM recovery_plans
+      WHERE recovery_plans.id = plan_steps.plan_id
+        AND recovery_plans.user_id = auth.uid()
+    )
+  );
+
+-- Users can insert steps for plans they own
+CREATE POLICY "Users can insert own plan steps"
+  ON plan_steps FOR INSERT
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM recovery_plans
+      WHERE recovery_plans.id = plan_steps.plan_id
+        AND recovery_plans.user_id = auth.uid()
+    )
+  );
+
+-- Users can update steps for plans they own (mark completed, etc.)
+CREATE POLICY "Users can update own plan steps"
+  ON plan_steps FOR UPDATE
+  USING (
+    EXISTS (
+      SELECT 1 FROM recovery_plans
+      WHERE recovery_plans.id = plan_steps.plan_id
+        AND recovery_plans.user_id = auth.uid()
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM recovery_plans
+      WHERE recovery_plans.id = plan_steps.plan_id
+        AND recovery_plans.user_id = auth.uid()
+    )
+  );
+
+-- Anonymous users can insert steps for anonymous plans (null user_id)
+CREATE POLICY "Anonymous users can insert plan steps for anonymous plans"
+  ON plan_steps FOR INSERT
+  TO anon
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM recovery_plans
+      WHERE recovery_plans.id = plan_steps.plan_id
+        AND recovery_plans.user_id IS NULL
+    )
+  );

--- a/scorerebound/supabase/migrations/20260316000005_create_progress_entries.sql
+++ b/scorerebound/supabase/migrations/20260316000005_create_progress_entries.sql
@@ -1,0 +1,37 @@
+-- Migration: Create progress_entries table
+-- Credit score snapshots and milestone logs for tracking recovery progress
+
+CREATE TABLE progress_entries (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  plan_id uuid NOT NULL REFERENCES recovery_plans(id) ON DELETE CASCADE,
+  action_type text NOT NULL,
+  action_description text,
+  score_snapshot integer CHECK (score_snapshot IS NULL OR (score_snapshot >= 300 AND score_snapshot <= 850)),
+  completed_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- Indexes for common queries
+CREATE INDEX idx_progress_entries_user_id ON progress_entries (user_id);
+CREATE INDEX idx_progress_entries_plan_id ON progress_entries (plan_id);
+CREATE INDEX idx_progress_entries_completed_at ON progress_entries (completed_at);
+
+-- RLS: user-owns-row pattern (requires authentication)
+ALTER TABLE progress_entries ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view own progress entries"
+  ON progress_entries FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can insert own progress entries"
+  ON progress_entries FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can update own progress entries"
+  ON progress_entries FOR UPDATE
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can delete own progress entries"
+  ON progress_entries FOR DELETE
+  USING (auth.uid() = user_id);

--- a/scorerebound/supabase/migrations/20260316000006_create_affiliate_clicks.sql
+++ b/scorerebound/supabase/migrations/20260316000006_create_affiliate_clicks.sql
@@ -1,0 +1,36 @@
+-- Migration: Create affiliate_clicks table
+-- Tracks referral clicks to credit-builder products, secured cards, monitoring, refinancing
+
+CREATE TABLE affiliate_clicks (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  product_slug text NOT NULL,
+  affiliate_url text NOT NULL,
+  referrer_page text,
+  clicked_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- Indexes for analytics queries
+CREATE INDEX idx_affiliate_clicks_user_id ON affiliate_clicks (user_id);
+CREATE INDEX idx_affiliate_clicks_product_slug ON affiliate_clicks (product_slug);
+CREATE INDEX idx_affiliate_clicks_clicked_at ON affiliate_clicks (clicked_at);
+
+-- RLS: anyone can insert, authenticated users can view their own
+ALTER TABLE affiliate_clicks ENABLE ROW LEVEL SECURITY;
+
+-- Authenticated users can view their own clicks
+CREATE POLICY "Users can view own affiliate clicks"
+  ON affiliate_clicks FOR SELECT
+  USING (auth.uid() = user_id);
+
+-- Authenticated users can insert clicks
+CREATE POLICY "Authenticated users can create affiliate clicks"
+  ON affiliate_clicks FOR INSERT
+  TO authenticated
+  WITH CHECK (user_id IS NULL OR auth.uid() = user_id);
+
+-- Anonymous users can insert clicks with null user_id
+CREATE POLICY "Anonymous users can create affiliate clicks"
+  ON affiliate_clicks FOR INSERT
+  TO anon
+  WITH CHECK (user_id IS NULL);

--- a/scorerebound/supabase/migrations/20260316000007_create_email_sequences.sql
+++ b/scorerebound/supabase/migrations/20260316000007_create_email_sequences.sql
@@ -1,0 +1,47 @@
+-- Migration: Create email_sequences table
+-- Drip campaign state per user for recovery guidance emails
+
+CREATE TABLE email_sequences (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  sequence_name text NOT NULL,
+  current_step integer NOT NULL DEFAULT 0,
+  status email_sequence_status NOT NULL DEFAULT 'active',
+  last_sent_at timestamptz,
+  next_send_at timestamptz,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- Indexes for common queries
+CREATE INDEX idx_email_sequences_user_id ON email_sequences (user_id);
+CREATE INDEX idx_email_sequences_status ON email_sequences (status);
+CREATE INDEX idx_email_sequences_next_send_at ON email_sequences (next_send_at)
+  WHERE status = 'active';
+
+-- Unique constraint: one sequence per user per sequence_name
+CREATE UNIQUE INDEX idx_email_sequences_user_sequence
+  ON email_sequences (user_id, sequence_name);
+
+-- Auto-update updated_at
+CREATE TRIGGER email_sequences_updated_at
+  BEFORE UPDATE ON email_sequences
+  FOR EACH ROW
+  EXECUTE FUNCTION update_updated_at();
+
+-- RLS: user-owns-row pattern
+ALTER TABLE email_sequences ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view own email sequences"
+  ON email_sequences FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can insert own email sequences"
+  ON email_sequences FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can update own email sequences"
+  ON email_sequences FOR UPDATE
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);

--- a/scorerebound/supabase/seed.sql
+++ b/scorerebound/supabase/seed.sql
@@ -1,0 +1,383 @@
+-- Seed data for ScoreRebound development and testing
+-- Idempotent: uses ON CONFLICT DO NOTHING so running twice is safe
+--
+-- Test accounts use predictable UUIDs so Playwright tests can reference them.
+-- These are only inserted in local/test environments via `supabase db reset`.
+
+-- ============================================================================
+-- Test user UUIDs (predictable for Playwright/CI)
+-- ============================================================================
+-- test-user-1: test@scorerebound.dev / password: testpass123
+-- test-user-2: test2@scorerebound.dev / password: testpass123
+-- test-anon:   anonymous session user
+
+-- Insert test users into auth.users (Supabase Auth)
+-- The on_auth_user_created trigger will auto-create profiles
+INSERT INTO auth.users (
+  id,
+  instance_id,
+  aud,
+  role,
+  email,
+  encrypted_password,
+  email_confirmed_at,
+  raw_app_meta_data,
+  raw_user_meta_data,
+  created_at,
+  updated_at,
+  confirmation_token,
+  email_change,
+  email_change_token_new,
+  recovery_token
+) VALUES (
+  '00000000-0000-0000-0000-000000000001',
+  '00000000-0000-0000-0000-000000000000',
+  'authenticated',
+  'authenticated',
+  'test@scorerebound.dev',
+  crypt('testpass123', gen_salt('bf')),
+  now(),
+  '{"provider": "email", "providers": ["email"]}'::jsonb,
+  '{"display_name": "Test User"}'::jsonb,
+  now(),
+  now(),
+  '',
+  '',
+  '',
+  ''
+), (
+  '00000000-0000-0000-0000-000000000002',
+  '00000000-0000-0000-0000-000000000000',
+  'authenticated',
+  'authenticated',
+  'test2@scorerebound.dev',
+  crypt('testpass123', gen_salt('bf')),
+  now(),
+  '{"provider": "email", "providers": ["email"]}'::jsonb,
+  '{"display_name": "Test User 2"}'::jsonb,
+  now(),
+  now(),
+  '',
+  '',
+  '',
+  ''
+), (
+  '00000000-0000-0000-0000-000000000003',
+  '00000000-0000-0000-0000-000000000000',
+  'authenticated',
+  'authenticated',
+  'anon@scorerebound.dev',
+  crypt('testpass123', gen_salt('bf')),
+  now(),
+  '{"provider": "email", "providers": ["email"]}'::jsonb,
+  '{"display_name": "Anonymous Test"}'::jsonb,
+  now(),
+  now(),
+  '',
+  '',
+  '',
+  ''
+)
+ON CONFLICT (id) DO NOTHING;
+
+-- Insert identities for test users (required by Supabase Auth)
+INSERT INTO auth.identities (
+  id,
+  user_id,
+  provider_id,
+  identity_data,
+  provider,
+  last_sign_in_at,
+  created_at,
+  updated_at
+) VALUES (
+  '00000000-0000-0000-0000-000000000001',
+  '00000000-0000-0000-0000-000000000001',
+  'test@scorerebound.dev',
+  '{"sub": "00000000-0000-0000-0000-000000000001", "email": "test@scorerebound.dev"}'::jsonb,
+  'email',
+  now(),
+  now(),
+  now()
+), (
+  '00000000-0000-0000-0000-000000000002',
+  '00000000-0000-0000-0000-000000000002',
+  'test2@scorerebound.dev',
+  '{"sub": "00000000-0000-0000-0000-000000000002", "email": "test2@scorerebound.dev"}'::jsonb,
+  'email',
+  now(),
+  now(),
+  now()
+), (
+  '00000000-0000-0000-0000-000000000003',
+  '00000000-0000-0000-0000-000000000003',
+  'anon@scorerebound.dev',
+  '{"sub": "00000000-0000-0000-0000-000000000003", "email": "anon@scorerebound.dev"}'::jsonb,
+  'email',
+  now(),
+  now(),
+  now()
+)
+ON CONFLICT (id) DO NOTHING;
+
+-- ============================================================================
+-- Update profiles created by the trigger with display names
+-- ============================================================================
+UPDATE profiles SET
+  display_name = 'Test User',
+  score_range = '500_579',
+  is_anonymous = false
+WHERE id = '00000000-0000-0000-0000-000000000001';
+
+UPDATE profiles SET
+  display_name = 'Test User 2',
+  score_range = '620_659',
+  is_anonymous = false
+WHERE id = '00000000-0000-0000-0000-000000000002';
+
+UPDATE profiles SET
+  display_name = 'Anonymous Test',
+  is_anonymous = true
+WHERE id = '00000000-0000-0000-0000-000000000003';
+
+-- ============================================================================
+-- Sample quiz responses
+-- ============================================================================
+INSERT INTO quiz_responses (id, user_id, loan_type, servicer, delinquency_status, current_score_range, goals) VALUES
+(
+  '10000000-0000-0000-0000-000000000001',
+  '00000000-0000-0000-0000-000000000001',
+  'federal_direct',
+  'MOHELA',
+  '90_plus',
+  '500_579',
+  ARRAY['improve_credit_score', 'get_out_of_default', 'qualify_for_mortgage']
+),
+(
+  '10000000-0000-0000-0000-000000000002',
+  '00000000-0000-0000-0000-000000000002',
+  'parent_plus',
+  'Nelnet',
+  '60_days',
+  '620_659',
+  ARRAY['lower_monthly_payment', 'improve_credit_score']
+),
+-- Anonymous quiz response (no user_id)
+(
+  '10000000-0000-0000-0000-000000000003',
+  NULL,
+  'federal_ffel',
+  'Aidvantage',
+  'default',
+  '300_499',
+  ARRAY['get_out_of_default', 'stop_wage_garnishment']
+)
+ON CONFLICT (id) DO NOTHING;
+
+-- ============================================================================
+-- Sample recovery plans
+-- ============================================================================
+INSERT INTO recovery_plans (id, quiz_response_id, user_id, plan_json, recovery_path, estimated_months) VALUES
+(
+  '20000000-0000-0000-0000-000000000001',
+  '10000000-0000-0000-0000-000000000001',
+  '00000000-0000-0000-0000-000000000001',
+  '{
+    "title": "Federal Direct Loan Recovery via Rehabilitation",
+    "summary": "Your best path is loan rehabilitation: 9 consecutive on-time payments to remove the default from your credit report.",
+    "steps_overview": ["Contact MOHELA", "Enroll in rehabilitation", "Set up auto-pay", "Apply for IBR after rehabilitation", "Monitor credit score"],
+    "estimated_score_improvement": "80-120 points",
+    "warnings": ["Do not consolidate before rehabilitation if you want the default removed from credit report"]
+  }'::jsonb,
+  'rehabilitation',
+  12
+),
+(
+  '20000000-0000-0000-0000-000000000002',
+  '10000000-0000-0000-0000-000000000002',
+  '00000000-0000-0000-0000-000000000002',
+  '{
+    "title": "Parent PLUS Loan IBR Enrollment",
+    "summary": "Consolidate your Parent PLUS loan to access IBR repayment plans and lower your monthly payment.",
+    "steps_overview": ["Apply for Direct Consolidation", "Enroll in ICR plan", "Set up auto-pay for 0.25% rate reduction", "Monitor payment status"],
+    "estimated_score_improvement": "40-60 points",
+    "warnings": ["Parent PLUS loans only qualify for ICR, not other IBR plans, unless consolidated"]
+  }'::jsonb,
+  'ibr_enrollment',
+  9
+),
+-- Anonymous recovery plan
+(
+  '20000000-0000-0000-0000-000000000003',
+  '10000000-0000-0000-0000-000000000003',
+  NULL,
+  '{
+    "title": "FFEL Loan Default Recovery",
+    "summary": "Consolidation is your fastest path out of default for FFEL loans. This will stop collections and give you access to IBR.",
+    "steps_overview": ["Request consolidation application", "Choose IBR plan during consolidation", "Set up auto-pay", "Apply for credit-builder loan"],
+    "estimated_score_improvement": "60-100 points",
+    "warnings": ["Consolidation does NOT remove the default from your credit report (only rehabilitation does)"]
+  }'::jsonb,
+  'consolidation',
+  6
+)
+ON CONFLICT (id) DO NOTHING;
+
+-- ============================================================================
+-- Sample plan steps
+-- ============================================================================
+INSERT INTO plan_steps (id, plan_id, step_order, title, description, action_url, is_completed, completed_at) VALUES
+-- Steps for Plan 1 (Rehabilitation)
+(
+  '30000000-0000-0000-0000-000000000001',
+  '20000000-0000-0000-0000-000000000001',
+  1,
+  'Contact MOHELA',
+  'Call MOHELA at 1-888-866-4352 and request loan rehabilitation. Ask about your rehabilitation payment amount.',
+  'https://www.mohela.com/DL/resourceCenter/ContactUs.aspx',
+  true,
+  now() - interval '30 days'
+),
+(
+  '30000000-0000-0000-0000-000000000002',
+  '20000000-0000-0000-0000-000000000001',
+  2,
+  'Sign Rehabilitation Agreement',
+  'Review and sign the rehabilitation agreement. Your payment will be 15% of discretionary income divided by 12.',
+  NULL,
+  true,
+  now() - interval '25 days'
+),
+(
+  '30000000-0000-0000-0000-000000000003',
+  '20000000-0000-0000-0000-000000000001',
+  3,
+  'Make 9 Consecutive Payments',
+  'Make 9 on-time monthly payments within 20 days of the due date. Set up auto-pay to avoid missing any.',
+  NULL,
+  false,
+  NULL
+),
+(
+  '30000000-0000-0000-0000-000000000004',
+  '20000000-0000-0000-0000-000000000001',
+  4,
+  'Apply for IBR After Rehabilitation',
+  'Once rehabilitation is complete, apply for an Income-Based Repayment plan to keep payments affordable.',
+  'https://studentaid.gov/idr/',
+  false,
+  NULL
+),
+(
+  '30000000-0000-0000-0000-000000000005',
+  '20000000-0000-0000-0000-000000000001',
+  5,
+  'Monitor Credit Score Recovery',
+  'Check your credit report 30-60 days after rehabilitation completes. The default should be removed.',
+  NULL,
+  false,
+  NULL
+),
+-- Steps for Plan 2 (IBR Enrollment)
+(
+  '30000000-0000-0000-0000-000000000006',
+  '20000000-0000-0000-0000-000000000002',
+  1,
+  'Apply for Direct Consolidation',
+  'Apply at studentaid.gov to consolidate your Parent PLUS loan into a Direct Consolidation Loan.',
+  'https://studentaid.gov/app/launchConsolidation.action',
+  false,
+  NULL
+),
+(
+  '30000000-0000-0000-0000-000000000007',
+  '20000000-0000-0000-0000-000000000002',
+  2,
+  'Select ICR Repayment Plan',
+  'During consolidation, select Income-Contingent Repayment (ICR). This is the only income-driven plan available for consolidated Parent PLUS loans.',
+  NULL,
+  false,
+  NULL
+)
+ON CONFLICT (id) DO NOTHING;
+
+-- ============================================================================
+-- Sample progress entries
+-- ============================================================================
+INSERT INTO progress_entries (id, user_id, plan_id, action_type, action_description, score_snapshot, completed_at) VALUES
+(
+  '40000000-0000-0000-0000-000000000001',
+  '00000000-0000-0000-0000-000000000001',
+  '20000000-0000-0000-0000-000000000001',
+  'score_check',
+  'Initial credit score check before starting rehabilitation',
+  520,
+  now() - interval '35 days'
+),
+(
+  '40000000-0000-0000-0000-000000000002',
+  '00000000-0000-0000-0000-000000000001',
+  '20000000-0000-0000-0000-000000000001',
+  'milestone',
+  'Contacted MOHELA and started rehabilitation process',
+  NULL,
+  now() - interval '30 days'
+),
+(
+  '40000000-0000-0000-0000-000000000003',
+  '00000000-0000-0000-0000-000000000001',
+  '20000000-0000-0000-0000-000000000001',
+  'score_check',
+  'Monthly credit score check - slight improvement after starting rehab',
+  535,
+  now() - interval '5 days'
+)
+ON CONFLICT (id) DO NOTHING;
+
+-- ============================================================================
+-- Sample affiliate clicks
+-- ============================================================================
+INSERT INTO affiliate_clicks (id, user_id, product_slug, affiliate_url, referrer_page, clicked_at) VALUES
+(
+  '50000000-0000-0000-0000-000000000001',
+  '00000000-0000-0000-0000-000000000001',
+  'self-credit-builder',
+  'https://www.self.inc/refer/scorerebound',
+  '/recovery-plan',
+  now() - interval '10 days'
+),
+(
+  '50000000-0000-0000-0000-000000000002',
+  NULL,
+  'discover-secured-card',
+  'https://www.discover.com/credit-cards/secured/',
+  '/recovery-paths/credit-building',
+  now() - interval '3 days'
+)
+ON CONFLICT (id) DO NOTHING;
+
+-- ============================================================================
+-- Sample email sequences
+-- ============================================================================
+INSERT INTO email_sequences (id, user_id, sequence_name, current_step, status, last_sent_at, next_send_at, metadata) VALUES
+(
+  '60000000-0000-0000-0000-000000000001',
+  '00000000-0000-0000-0000-000000000001',
+  'rehabilitation_drip',
+  3,
+  'active',
+  now() - interval '3 days',
+  now() + interval '4 days',
+  '{"quiz_response_id": "10000000-0000-0000-0000-000000000001", "recovery_path": "rehabilitation"}'::jsonb
+),
+(
+  '60000000-0000-0000-0000-000000000002',
+  '00000000-0000-0000-0000-000000000002',
+  'ibr_enrollment_drip',
+  1,
+  'active',
+  now() - interval '1 day',
+  now() + interval '6 days',
+  '{"quiz_response_id": "10000000-0000-0000-0000-000000000002", "recovery_path": "ibr_enrollment"}'::jsonb
+)
+ON CONFLICT (id) DO NOTHING;

--- a/scorerebound/tsconfig.json
+++ b/scorerebound/tsconfig.json
@@ -30,5 +30,5 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules", "e2e"]
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary

Implements the complete Supabase database schema for ScoreRebound (closes #4).

- **7 migration files** creating all core tables: `profiles`, `quiz_responses`, `recovery_plans`, `plan_steps`, `progress_entries`, `affiliate_clicks`, `email_sequences`
- **5 custom PostgreSQL enums**: `loan_type`, `recovery_path`, `delinquency_status`, `score_range`, `email_sequence_status`
- **RLS policies** on all tables enforcing user-owns-row pattern, with anonymous INSERT support on `quiz_responses`, `recovery_plans`, `affiliate_clicks`, and `plan_steps` (for anonymous recovery plans)
- **Idempotent seed data** with 3 predictable test users (UUIDs for Playwright), sample quiz responses, recovery plans with steps, progress entries, affiliate clicks, and email sequences
- **TypeScript types** (`database.types.ts`): Row, Insert, Update types for all tables plus `Database` generic compatible with `@supabase/supabase-js`
- **Supabase client** (`supabase.ts`): lazy-initialized client with env validation, server client helper with JSDoc server-only annotation
- **27 unit tests** covering all enum types, row shapes, insert/update type contracts, and Database structure
- **Fixes from learnings**: removed `e2e` from tsconfig exclude, removed deprecated `next/typescript` from ESLint config

## Verification

- `bun run test` — 27 tests passing (2 test files)
- `bun run lint` — no warnings or errors
- `bun run typecheck` — clean
- `bun run build` — successful production build
- All changes confined to `scorerebound/` — no scope creep

## Test plan

- [ ] Verify `supabase db reset` applies all 7 migrations and seeds data correctly
- [ ] Verify RLS policies: authenticated user can only access own rows
- [ ] Verify anonymous users can insert quiz_responses and recovery_plans
- [ ] Verify TypeScript types match SQL schema columns and constraints
- [ ] Verify `supabase gen types typescript` output matches hand-written types

🤖 Generated with [Claude Code](https://claude.com/claude-code)