### PR TITLE
fix(scorerebound): add nodejs_compat flag — fixes production 503

### DIFF
--- a/scorerebound/wrangler.toml
+++ b/scorerebound/wrangler.toml
@@ -1,3 +1,4 @@
 name = "scorerebound"
 pages_build_output_dir = "out"
 compatibility_date = "2025-04-01"
+compatibility_flags = ["nodejs_compat"]


### PR DESCRIPTION
## Summary

Fixes #281 — **CRITICAL: Production 503**

ScoreRebound at `scorerebound.pages.dev` was returning 503 errors because `wrangler.toml` was missing the `nodejs_compat` compatibility flag required by Cloudflare Pages to run Next.js server-side code (API routes, SSR).

### Changes
- Added `compatibility_flags = ["nodejs_compat"]` to `scorerebound/wrangler.toml`

### Verification
- `bun run build` ✅
- `bun run test` ✅ (81 tests passing)
- `bun run lint` ✅
- `bash scripts/validate-pr.sh scorerebound` ✅

## Test plan
- [ ] After merge+deploy, verify `curl -s -o /dev/null -w '%{http_code}' https://scorerebound.pages.dev` returns 200
- [ ] Verify `curl -s -o /dev/null -w '%{http_code}' https://scorerebound.pages.dev/api/health` returns 200
- [ ] Verify all pages load without 503 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)