### PR TITLE
feat(scorerebound): SEO content pages — guides + servicer pages + sitemap (closes #286)

### DIFF
--- a/scorerebound/package.json
+++ b/scorerebound/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scorerebound",
-  "version": "0.3.2",
+  "version": "0.4.1",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/scorerebound/src/app/guides/ibr-enrollment/page.tsx
+++ b/scorerebound/src/app/guides/ibr-enrollment/page.tsx
@@ -1,0 +1,457 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import QuizCTA from "@/components/QuizCTA";
+import FAQSchema, { type FAQItem } from "@/components/FAQSchema";
+
+export const metadata: Metadata = {
+  title:
+    "Income-Based Repayment (IBR) Enrollment Guide — ScoreRebound",
+  description:
+    "Step-by-step guide to enrolling in Income-Based Repayment (IBR) for federal student loans. Lower your monthly payment, avoid default, and start recovering your credit score.",
+  openGraph: {
+    title: "Income-Based Repayment (IBR) Enrollment Guide — ScoreRebound",
+    description:
+      "Step-by-step guide to enrolling in IBR. Lower your monthly payment based on your income and family size.",
+    type: "article",
+    siteName: "ScoreRebound",
+  },
+};
+
+const faqs: FAQItem[] = [
+  {
+    question: "What is Income-Based Repayment (IBR)?",
+    answer:
+      "Income-Based Repayment (IBR) is a federal student loan repayment plan that caps your monthly payment at 10-15% of your discretionary income. If your income is low enough, your payment could be as low as $0 per month. After 20-25 years of qualifying payments, any remaining balance is forgiven.",
+  },
+  {
+    question: "Who is eligible for IBR?",
+    answer:
+      "You are eligible for IBR if you have federal Direct Loans or FFEL loans and can demonstrate partial financial hardship — meaning your IBR payment would be less than what you'd pay under the standard 10-year repayment plan. Parent PLUS loans are not directly eligible but can qualify after consolidation.",
+  },
+  {
+    question: "How do I apply for IBR?",
+    answer:
+      "You can apply for IBR online at studentaid.gov using the Income-Driven Repayment (IDR) application. You'll need your most recent tax return or pay stubs to verify your income. The application takes about 10 minutes. Your servicer will notify you of your new payment amount within 1-2 weeks.",
+  },
+  {
+    question: "Will IBR remove late payments from my credit report?",
+    answer:
+      "No, IBR will not remove existing late payment records from your credit report. However, enrolling in IBR makes your payments affordable so you can make on-time payments going forward. Consistent on-time payments are the single most important factor in credit score recovery. Late payments become less impactful over time and fall off your report after 7 years.",
+  },
+  {
+    question: "Can my IBR payment really be $0?",
+    answer:
+      "Yes. If your adjusted gross income is at or below 150% of the federal poverty guideline for your family size, your IBR payment will be $0/month. A $0 payment still counts as an 'on-time payment' for forgiveness purposes and will not generate new negative marks on your credit report.",
+  },
+  {
+    question: "How long does it take to get approved for IBR?",
+    answer:
+      "The IBR application process typically takes 1-2 weeks from submission to approval. During this time, contact your servicer to request forbearance so you don't incur additional late payments while waiting. Once approved, your new lower payment takes effect immediately.",
+  },
+];
+
+export default function IBREnrollmentGuide() {
+  return (
+    <>
+      <FAQSchema faqs={faqs} />
+
+      <article className="mx-auto max-w-4xl px-4 py-16 sm:px-6 lg:px-8">
+        {/* Breadcrumb */}
+        <nav data-testid="guide-breadcrumb" className="mb-8 text-sm text-gray-500">
+          <Link href="/" data-testid="breadcrumb-home" className="hover:text-emerald-700">
+            Home
+          </Link>
+          <span className="mx-2">/</span>
+          <span className="text-gray-900">IBR Enrollment Guide</span>
+        </nav>
+
+        {/* Header */}
+        <header data-testid="guide-header">
+          <div className="mb-4 inline-flex items-center rounded-full border border-emerald-200 bg-emerald-50 px-3 py-1 text-sm font-medium text-emerald-700">
+            Recovery Path
+          </div>
+          <h1
+            data-testid="guide-title"
+            className="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl lg:text-5xl"
+          >
+            Income-Based Repayment (IBR) Enrollment Guide
+          </h1>
+          <p
+            data-testid="guide-description"
+            className="mt-6 text-lg leading-8 text-gray-600"
+          >
+            If your student loan payments are unaffordable and you are falling behind,
+            Income-Based Repayment can lower your monthly payment to as little as $0
+            based on your income. This guide walks you through everything you need to
+            know to enroll and start recovering your credit score.
+          </p>
+        </header>
+
+        {/* Key Stats */}
+        <div
+          data-testid="guide-key-stats"
+          className="my-12 grid grid-cols-1 gap-4 sm:grid-cols-3"
+        >
+          <div className="rounded-xl border border-gray-200 bg-gray-50 p-6 text-center">
+            <p className="text-3xl font-bold text-emerald-600">10-15%</p>
+            <p className="mt-1 text-sm text-gray-600">
+              of discretionary income
+            </p>
+          </div>
+          <div className="rounded-xl border border-gray-200 bg-gray-50 p-6 text-center">
+            <p className="text-3xl font-bold text-emerald-600">$0</p>
+            <p className="mt-1 text-sm text-gray-600">
+              possible monthly payment
+            </p>
+          </div>
+          <div className="rounded-xl border border-gray-200 bg-gray-50 p-6 text-center">
+            <p className="text-3xl font-bold text-emerald-600">20-25 yr</p>
+            <p className="mt-1 text-sm text-gray-600">
+              forgiveness timeline
+            </p>
+          </div>
+        </div>
+
+        <QuizCTA />
+
+        {/* What is IBR */}
+        <section data-testid="guide-section-what-is-ibr" className="mt-16">
+          <h2 className="text-2xl font-bold text-gray-900">
+            What Is Income-Based Repayment?
+          </h2>
+          <p className="mt-4 text-gray-600 leading-7">
+            Income-Based Repayment (IBR) is one of several income-driven repayment (IDR)
+            plans offered by the federal government for student loans. Under IBR, your
+            monthly payment is capped at a percentage of your discretionary income — the
+            difference between your adjusted gross income and 150% of the poverty guideline
+            for your state and family size.
+          </p>
+          <p className="mt-4 text-gray-600 leading-7">
+            For borrowers who took out their first loans after July 1, 2014, the cap is
+            10% of discretionary income with forgiveness after 20 years. For earlier
+            borrowers, it is 15% with forgiveness after 25 years.
+          </p>
+          <p className="mt-4 text-gray-600 leading-7">
+            If your income is very low — at or below 150% of the federal poverty
+            guideline — your monthly payment will be $0. This still counts as a
+            qualifying payment for forgiveness and will not result in negative credit
+            reporting.
+          </p>
+        </section>
+
+        {/* Eligibility */}
+        <section data-testid="guide-section-eligibility" className="mt-12">
+          <h2 className="text-2xl font-bold text-gray-900">
+            Who Is Eligible for IBR?
+          </h2>
+          <p className="mt-4 text-gray-600 leading-7">
+            To qualify for IBR, you must meet these requirements:
+          </p>
+          <ul className="mt-4 space-y-3 text-gray-600">
+            <li className="flex gap-3">
+              <span className="mt-1 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-emerald-100 text-xs font-bold text-emerald-700">
+                1
+              </span>
+              <span>
+                <strong>Federal loans:</strong> You must have eligible federal student
+                loans — Direct Loans or FFEL loans. Private loans are not eligible.
+              </span>
+            </li>
+            <li className="flex gap-3">
+              <span className="mt-1 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-emerald-100 text-xs font-bold text-emerald-700">
+                2
+              </span>
+              <span>
+                <strong>Partial financial hardship:</strong> Your calculated IBR payment
+                must be less than what you would pay under the standard 10-year repayment
+                plan.
+              </span>
+            </li>
+            <li className="flex gap-3">
+              <span className="mt-1 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-emerald-100 text-xs font-bold text-emerald-700">
+                3
+              </span>
+              <span>
+                <strong>Not in default:</strong> If your loans are in default, you must
+                first rehabilitate or consolidate them before you can enroll in IBR. See
+                our{" "}
+                <Link
+                  href="/guides/loan-rehabilitation"
+                  data-testid="guide-link-rehabilitation"
+                  className="font-medium text-emerald-600 hover:text-emerald-500"
+                >
+                  Loan Rehabilitation Guide
+                </Link>{" "}
+                or{" "}
+                <Link
+                  href="/guides/loan-consolidation"
+                  data-testid="guide-link-consolidation"
+                  className="font-medium text-emerald-600 hover:text-emerald-500"
+                >
+                  Consolidation Guide
+                </Link>
+                .
+              </span>
+            </li>
+          </ul>
+          <div className="mt-6 rounded-lg border border-amber-200 bg-amber-50 p-4">
+            <p className="text-sm text-amber-800">
+              <strong>Parent PLUS loans:</strong> Parent PLUS loans are not directly
+              eligible for IBR. However, if you consolidate your Parent PLUS loans
+              into a Direct Consolidation Loan, you can access the Income-Contingent
+              Repayment (ICR) plan.
+            </p>
+          </div>
+        </section>
+
+        {/* Step by Step */}
+        <section data-testid="guide-section-steps" className="mt-12">
+          <h2 className="text-2xl font-bold text-gray-900">
+            How to Enroll in IBR: Step by Step
+          </h2>
+          <div className="mt-8 space-y-8">
+            <div className="flex gap-4">
+              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-emerald-600 text-lg font-bold text-white">
+                1
+              </div>
+              <div>
+                <h3 className="text-lg font-semibold text-gray-900">
+                  Gather your documents
+                </h3>
+                <p className="mt-2 text-gray-600 leading-7">
+                  You will need your most recent federal tax return (or tax transcript)
+                  and your current pay stubs if your income has changed since you last
+                  filed. If you are married and file jointly, your spouse&apos;s income
+                  will also be considered.
+                </p>
+              </div>
+            </div>
+
+            <div className="flex gap-4">
+              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-emerald-600 text-lg font-bold text-white">
+                2
+              </div>
+              <div>
+                <h3 className="text-lg font-semibold text-gray-900">
+                  Submit the IDR application on studentaid.gov
+                </h3>
+                <p className="mt-2 text-gray-600 leading-7">
+                  Go to{" "}
+                  <a
+                    href="https://studentaid.gov/app/ibrInstructions.action"
+                    data-testid="guide-link-studentaid"
+                    className="font-medium text-emerald-600 hover:text-emerald-500"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    studentaid.gov
+                  </a>{" "}
+                  and complete the Income-Driven Repayment application. Select IBR as
+                  your preferred plan (or let the system recommend the best plan for you).
+                  The application takes about 10 minutes.
+                </p>
+              </div>
+            </div>
+
+            <div className="flex gap-4">
+              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-emerald-600 text-lg font-bold text-white">
+                3
+              </div>
+              <div>
+                <h3 className="text-lg font-semibold text-gray-900">
+                  Request forbearance while your application processes
+                </h3>
+                <p className="mt-2 text-gray-600 leading-7">
+                  Call your servicer and ask for administrative forbearance during the
+                  processing period. This prevents additional late payments while you
+                  wait for approval. Processing typically takes 1-2 weeks.
+                </p>
+              </div>
+            </div>
+
+            <div className="flex gap-4">
+              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-emerald-600 text-lg font-bold text-white">
+                4
+              </div>
+              <div>
+                <h3 className="text-lg font-semibold text-gray-900">
+                  Set up automatic payments
+                </h3>
+                <p className="mt-2 text-gray-600 leading-7">
+                  Once approved, enroll in autopay with your servicer. Autopay ensures
+                  you never miss a payment (the #1 factor in credit recovery) and most
+                  servicers offer a 0.25% interest rate reduction for enrollment.
+                </p>
+              </div>
+            </div>
+
+            <div className="flex gap-4">
+              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-emerald-600 text-lg font-bold text-white">
+                5
+              </div>
+              <div>
+                <h3 className="text-lg font-semibold text-gray-900">
+                  Recertify your income annually
+                </h3>
+                <p className="mt-2 text-gray-600 leading-7">
+                  IBR requires annual income recertification. Your servicer will notify
+                  you when it is time. If you miss the deadline, your payment may
+                  temporarily increase to the standard amount. Set a calendar reminder
+                  60 days before your recertification date.
+                </p>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* Credit Impact */}
+        <section data-testid="guide-section-credit-impact" className="mt-12">
+          <h2 className="text-2xl font-bold text-gray-900">
+            How IBR Affects Your Credit Score
+          </h2>
+          <p className="mt-4 text-gray-600 leading-7">
+            Enrolling in IBR does not directly remove past late payments from your credit
+            report. However, it is one of the most powerful tools for credit recovery
+            because it makes your payments affordable, allowing you to make consistent
+            on-time payments going forward.
+          </p>
+          <div className="mt-6 space-y-4">
+            <div className="rounded-lg border border-gray-200 p-4">
+              <h3 className="font-semibold text-gray-900">Payment history (35% of your score)</h3>
+              <p className="mt-1 text-sm text-gray-600">
+                Each on-time IBR payment adds positive history. After 12-24 months of
+                consistent payments, most borrowers see significant score improvement.
+              </p>
+            </div>
+            <div className="rounded-lg border border-gray-200 p-4">
+              <h3 className="font-semibold text-gray-900">Delinquency aging (time heals)</h3>
+              <p className="mt-1 text-sm text-gray-600">
+                Past late payments become less impactful over time. A late payment from
+                18 months ago hurts much less than one from last month. IBR stops new
+                delinquencies from appearing.
+              </p>
+            </div>
+            <div className="rounded-lg border border-gray-200 p-4">
+              <h3 className="font-semibold text-gray-900">Estimated recovery</h3>
+              <p className="mt-1 text-sm text-gray-600">
+                Most borrowers who enroll in IBR and make consistent on-time payments
+                see 30-80 points of credit score improvement within 3-9 months.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <QuizCTA />
+
+        {/* Pros and Cons */}
+        <section data-testid="guide-section-pros-cons" className="mt-16">
+          <h2 className="text-2xl font-bold text-gray-900">
+            IBR Pros and Cons
+          </h2>
+          <div className="mt-6 grid grid-cols-1 gap-6 sm:grid-cols-2">
+            <div className="rounded-xl border border-emerald-200 bg-emerald-50 p-6">
+              <h3 className="font-semibold text-emerald-800">Pros</h3>
+              <ul className="mt-3 space-y-2 text-sm text-emerald-900">
+                <li className="flex gap-2">
+                  <span>+</span>
+                  <span>Immediately lowers monthly payment</span>
+                </li>
+                <li className="flex gap-2">
+                  <span>+</span>
+                  <span>Payment can be $0 if income is very low</span>
+                </li>
+                <li className="flex gap-2">
+                  <span>+</span>
+                  <span>Remaining balance forgiven after 20-25 years</span>
+                </li>
+                <li className="flex gap-2">
+                  <span>+</span>
+                  <span>Stops further delinquencies from appearing</span>
+                </li>
+                <li className="flex gap-2">
+                  <span>+</span>
+                  <span>Qualifies for Public Service Loan Forgiveness (PSLF)</span>
+                </li>
+              </ul>
+            </div>
+            <div className="rounded-xl border border-red-200 bg-red-50 p-6">
+              <h3 className="font-semibold text-red-800">Cons</h3>
+              <ul className="mt-3 space-y-2 text-sm text-red-900">
+                <li className="flex gap-2">
+                  <span>-</span>
+                  <span>Does not remove existing late payments from credit report</span>
+                </li>
+                <li className="flex gap-2">
+                  <span>-</span>
+                  <span>Interest may capitalize (be added to principal)</span>
+                </li>
+                <li className="flex gap-2">
+                  <span>-</span>
+                  <span>Forgiven amount may be taxable as income</span>
+                </li>
+                <li className="flex gap-2">
+                  <span>-</span>
+                  <span>Must recertify income annually</span>
+                </li>
+              </ul>
+            </div>
+          </div>
+        </section>
+
+        {/* FAQ */}
+        <section data-testid="guide-section-faq" className="mt-12">
+          <h2 className="text-2xl font-bold text-gray-900">
+            Frequently Asked Questions
+          </h2>
+          <div className="mt-6 divide-y divide-gray-200">
+            {faqs.map((faq, index) => (
+              <div key={index} className="py-6">
+                <h3 className="text-lg font-semibold text-gray-900">
+                  {faq.question}
+                </h3>
+                <p className="mt-3 text-gray-600 leading-7">{faq.answer}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* Related Guides */}
+        <section data-testid="guide-section-related" className="mt-12">
+          <h2 className="text-2xl font-bold text-gray-900">
+            Related Recovery Guides
+          </h2>
+          <div className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <Link
+              href="/guides/loan-rehabilitation"
+              data-testid="related-link-rehabilitation"
+              className="rounded-xl border border-gray-200 p-6 hover:border-emerald-300 hover:shadow-md transition-all"
+            >
+              <h3 className="font-semibold text-gray-900">
+                Loan Rehabilitation Guide
+              </h3>
+              <p className="mt-2 text-sm text-gray-600">
+                Already in default? Learn how to make 9 payments to remove the
+                default from your credit report.
+              </p>
+            </Link>
+            <Link
+              href="/guides/loan-consolidation"
+              data-testid="related-link-consolidation"
+              className="rounded-xl border border-gray-200 p-6 hover:border-emerald-300 hover:shadow-md transition-all"
+            >
+              <h3 className="font-semibold text-gray-900">
+                Consolidation Guide
+              </h3>
+              <p className="mt-2 text-sm text-gray-600">
+                Combine multiple loans into one and get current immediately.
+                Faster than rehabilitation.
+              </p>
+            </Link>
+          </div>
+        </section>
+
+        <QuizCTA />
+      </article>
+    </>
+  );
+}

--- a/scorerebound/src/app/guides/loan-consolidation/page.tsx
+++ b/scorerebound/src/app/guides/loan-consolidation/page.tsx
@@ -1,0 +1,442 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import QuizCTA from "@/components/QuizCTA";
+import FAQSchema, { type FAQItem } from "@/components/FAQSchema";
+
+export const metadata: Metadata = {
+  title:
+    "Student Loan Consolidation Guide — Get Current Immediately | ScoreRebound",
+  description:
+    "Complete guide to Direct Consolidation Loans. Combine multiple federal loans, get out of default immediately, and access income-driven repayment plans.",
+  openGraph: {
+    title: "Student Loan Consolidation Guide — Get Current Immediately",
+    description:
+      "Combine multiple federal student loans into one. Brings defaulted loans current immediately. The fastest path out of default.",
+    type: "article",
+    siteName: "ScoreRebound",
+  },
+};
+
+const faqs: FAQItem[] = [
+  {
+    question: "What is a Direct Consolidation Loan?",
+    answer:
+      "A Direct Consolidation Loan combines multiple federal student loans into a single new loan with a fixed interest rate based on the weighted average of the loans being consolidated, rounded up to the nearest one-eighth of a percent. It simplifies repayment into one monthly payment and can resolve default status.",
+  },
+  {
+    question:
+      "Can I consolidate loans that are in default?",
+    answer:
+      "Yes. One of the primary benefits of consolidation is that it can resolve default status. If you consolidate defaulted loans, you must agree to repay the new consolidation loan under an income-driven repayment plan, or make three consecutive, voluntary, on-time monthly payments on the defaulted loan before consolidating.",
+  },
+  {
+    question: "Will consolidation remove the default from my credit report?",
+    answer:
+      "No. Unlike rehabilitation, consolidation does not remove the default notation from your credit report. The old defaulted loans will show as paid through consolidation, and the new consolidation loan will appear as current. The default record remains for 7 years from the original default date.",
+  },
+  {
+    question: "Can I consolidate Parent PLUS loans?",
+    answer:
+      "Yes. Parent PLUS loans can be consolidated into a Direct Consolidation Loan. This is particularly important because it is the only way to access income-driven repayment — specifically Income-Contingent Repayment (ICR) — for Parent PLUS loans. Note: a consolidated Parent PLUS loan cannot be combined with other federal student loans.",
+  },
+  {
+    question: "How long does consolidation take?",
+    answer:
+      "The consolidation process typically takes 30-60 days from application submission to completion. During this time, continue making payments on your existing loans to avoid additional delinquency. Once processed, your old loans are paid off and replaced by the new consolidation loan.",
+  },
+  {
+    question: "Will consolidation lower my interest rate?",
+    answer:
+      "Not typically. The interest rate on a consolidation loan is the weighted average of the rates on the loans being consolidated, rounded up to the nearest one-eighth of a percent. So it may be slightly higher. However, consolidation gives you access to income-driven repayment plans that can significantly lower your monthly payment.",
+  },
+];
+
+export default function LoanConsolidationGuide() {
+  return (
+    <>
+      <FAQSchema faqs={faqs} />
+
+      <article className="mx-auto max-w-4xl px-4 py-16 sm:px-6 lg:px-8">
+        {/* Breadcrumb */}
+        <nav data-testid="guide-breadcrumb" className="mb-8 text-sm text-gray-500">
+          <Link href="/" data-testid="breadcrumb-home" className="hover:text-emerald-700">
+            Home
+          </Link>
+          <span className="mx-2">/</span>
+          <span className="text-gray-900">Loan Consolidation Guide</span>
+        </nav>
+
+        {/* Header */}
+        <header data-testid="guide-header">
+          <div className="mb-4 inline-flex items-center rounded-full border border-emerald-200 bg-emerald-50 px-3 py-1 text-sm font-medium text-emerald-700">
+            Recovery Path
+          </div>
+          <h1
+            data-testid="guide-title"
+            className="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl lg:text-5xl"
+          >
+            Student Loan Consolidation Guide
+          </h1>
+          <p
+            data-testid="guide-description"
+            className="mt-6 text-lg leading-8 text-gray-600"
+          >
+            A Direct Consolidation Loan is the <strong>fastest way to get out of
+            default</strong> on federal student loans. It combines multiple loans
+            into one, immediately brings defaulted loans to current status, and
+            unlocks access to income-driven repayment plans. Here is everything
+            you need to know.
+          </p>
+        </header>
+
+        {/* Key Stats */}
+        <div
+          data-testid="guide-key-stats"
+          className="my-12 grid grid-cols-1 gap-4 sm:grid-cols-3"
+        >
+          <div className="rounded-xl border border-gray-200 bg-gray-50 p-6 text-center">
+            <p className="text-3xl font-bold text-emerald-600">30-60 days</p>
+            <p className="mt-1 text-sm text-gray-600">
+              to process and get current
+            </p>
+          </div>
+          <div className="rounded-xl border border-gray-200 bg-gray-50 p-6 text-center">
+            <p className="text-3xl font-bold text-emerald-600">1 payment</p>
+            <p className="mt-1 text-sm text-gray-600">
+              instead of multiple loans
+            </p>
+          </div>
+          <div className="rounded-xl border border-gray-200 bg-gray-50 p-6 text-center">
+            <p className="text-3xl font-bold text-emerald-600">IDR access</p>
+            <p className="mt-1 text-sm text-gray-600">
+              income-driven plans unlocked
+            </p>
+          </div>
+        </div>
+
+        <QuizCTA />
+
+        {/* What is Consolidation */}
+        <section data-testid="guide-section-what-is" className="mt-16">
+          <h2 className="text-2xl font-bold text-gray-900">
+            What Is a Direct Consolidation Loan?
+          </h2>
+          <p className="mt-4 text-gray-600 leading-7">
+            A Direct Consolidation Loan is a federal program that allows you to combine
+            multiple federal student loans into a single new loan. The new loan has a
+            fixed interest rate based on the weighted average of the rates on the loans
+            being consolidated, rounded up to the nearest one-eighth of a percent.
+          </p>
+          <p className="mt-4 text-gray-600 leading-7">
+            For borrowers in default, consolidation offers a critical benefit: it
+            immediately brings your loans to current status. While it does not remove the
+            default notation from your credit report (rehabilitation does that), it is
+            significantly faster — processing in weeks rather than the 9+ months required
+            for rehabilitation.
+          </p>
+          <p className="mt-4 text-gray-600 leading-7">
+            Consolidation is also the only path for Parent PLUS loan borrowers to access
+            income-driven repayment plans. After consolidating, Parent PLUS borrowers can
+            enroll in Income-Contingent Repayment (ICR).
+          </p>
+        </section>
+
+        {/* When to Choose */}
+        <section data-testid="guide-section-when-to-choose" className="mt-12">
+          <h2 className="text-2xl font-bold text-gray-900">
+            When Should You Choose Consolidation?
+          </h2>
+          <p className="mt-4 text-gray-600 leading-7">
+            Consolidation is the right choice in several scenarios:
+          </p>
+          <ul className="mt-4 space-y-3 text-gray-600">
+            <li className="flex gap-3">
+              <span className="mt-1 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-emerald-100 text-xs font-bold text-emerald-700">
+                1
+              </span>
+              <span>
+                <strong>You need to get current fast:</strong> If you are applying for a
+                mortgage, apartment, or job that requires a credit check, consolidation
+                brings your loans current in 30-60 days versus 9+ months for rehabilitation.
+              </span>
+            </li>
+            <li className="flex gap-3">
+              <span className="mt-1 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-emerald-100 text-xs font-bold text-emerald-700">
+                2
+              </span>
+              <span>
+                <strong>You already used rehabilitation:</strong> You can only rehabilitate
+                each loan once. If you have defaulted again, consolidation is your path back.
+              </span>
+            </li>
+            <li className="flex gap-3">
+              <span className="mt-1 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-emerald-100 text-xs font-bold text-emerald-700">
+                3
+              </span>
+              <span>
+                <strong>You have Parent PLUS loans:</strong> Consolidation is the only way
+                to access income-driven repayment for Parent PLUS borrowers.
+              </span>
+            </li>
+            <li className="flex gap-3">
+              <span className="mt-1 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-emerald-100 text-xs font-bold text-emerald-700">
+                4
+              </span>
+              <span>
+                <strong>You have multiple loans with different servicers:</strong> Consolidation
+                simplifies to one loan, one servicer, one monthly payment.
+              </span>
+            </li>
+          </ul>
+        </section>
+
+        {/* Step by Step */}
+        <section data-testid="guide-section-steps" className="mt-12">
+          <h2 className="text-2xl font-bold text-gray-900">
+            How to Consolidate: Step by Step
+          </h2>
+          <div className="mt-8 space-y-8">
+            <div className="flex gap-4">
+              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-emerald-600 text-lg font-bold text-white">
+                1
+              </div>
+              <div>
+                <h3 className="text-lg font-semibold text-gray-900">
+                  Check which loans you want to consolidate
+                </h3>
+                <p className="mt-2 text-gray-600 leading-7">
+                  Log into{" "}
+                  <a
+                    href="https://studentaid.gov"
+                    data-testid="guide-link-studentaid"
+                    className="font-medium text-emerald-600 hover:text-emerald-500"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    studentaid.gov
+                  </a>{" "}
+                  to see all your federal loans, their servicers, balances, and statuses.
+                  You can choose to consolidate all of them or only some. Private loans
+                  cannot be included.
+                </p>
+              </div>
+            </div>
+
+            <div className="flex gap-4">
+              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-emerald-600 text-lg font-bold text-white">
+                2
+              </div>
+              <div>
+                <h3 className="text-lg font-semibold text-gray-900">
+                  Submit the consolidation application
+                </h3>
+                <p className="mt-2 text-gray-600 leading-7">
+                  Apply online at{" "}
+                  <a
+                    href="https://studentaid.gov/app/launchConsolidation.action"
+                    data-testid="guide-link-consolidation-app"
+                    className="font-medium text-emerald-600 hover:text-emerald-500"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    studentaid.gov/consolidation
+                  </a>
+                  . During the application, you will select a repayment plan. If your
+                  loans are in default, you must select an income-driven repayment plan.
+                </p>
+              </div>
+            </div>
+
+            <div className="flex gap-4">
+              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-emerald-600 text-lg font-bold text-white">
+                3
+              </div>
+              <div>
+                <h3 className="text-lg font-semibold text-gray-900">
+                  Continue payments during processing
+                </h3>
+                <p className="mt-2 text-gray-600 leading-7">
+                  Processing takes 30-60 days. Continue making payments on your existing
+                  loans during this time to avoid additional delinquency. Your old loans
+                  will be paid off once the consolidation loan is finalized.
+                </p>
+              </div>
+            </div>
+
+            <div className="flex gap-4">
+              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-emerald-600 text-lg font-bold text-white">
+                4
+              </div>
+              <div>
+                <h3 className="text-lg font-semibold text-gray-900">
+                  Set up autopay with your new servicer
+                </h3>
+                <p className="mt-2 text-gray-600 leading-7">
+                  Once your consolidation loan is active, immediately enroll in autopay.
+                  This ensures on-time payments (critical for credit recovery) and often
+                  qualifies you for a 0.25% interest rate reduction.
+                </p>
+              </div>
+            </div>
+
+            <div className="flex gap-4">
+              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-emerald-600 text-lg font-bold text-white">
+                5
+              </div>
+              <div>
+                <h3 className="text-lg font-semibold text-gray-900">
+                  Start building positive credit history
+                </h3>
+                <p className="mt-2 text-gray-600 leading-7">
+                  With your loans now current, pair consolidation with a{" "}
+                  <Link
+                    href="/guides/ibr-enrollment"
+                    data-testid="guide-link-ibr"
+                    className="font-medium text-emerald-600 hover:text-emerald-500"
+                  >
+                    credit-building strategy
+                  </Link>{" "}
+                  — a secured credit card or credit-builder loan adds positive payment
+                  history that accelerates your score recovery.
+                </p>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* Credit Impact */}
+        <section data-testid="guide-section-credit-impact" className="mt-12">
+          <h2 className="text-2xl font-bold text-gray-900">
+            Credit Score Impact of Consolidation
+          </h2>
+          <p className="mt-4 text-gray-600 leading-7">
+            Consolidation provides immediate relief by bringing your loans to current
+            status, but the credit impact is different from rehabilitation:
+          </p>
+          <div className="mt-6 space-y-4">
+            <div className="rounded-lg border border-gray-200 p-4">
+              <h3 className="font-semibold text-gray-900">Immediate: Loans show as current</h3>
+              <p className="mt-1 text-sm text-gray-600">
+                Your old defaulted loans will show as &quot;paid through consolidation&quot;
+                and the new consolidation loan appears as current. This stops new negative
+                marks immediately.
+              </p>
+            </div>
+            <div className="rounded-lg border border-gray-200 p-4">
+              <h3 className="font-semibold text-gray-900">Default record remains</h3>
+              <p className="mt-1 text-sm text-gray-600">
+                Unlike rehabilitation, the default notation stays on your credit report
+                for 7 years from the original default date. However, its impact
+                diminishes over time, especially as you build positive payment history.
+              </p>
+            </div>
+            <div className="rounded-lg border border-gray-200 p-4">
+              <h3 className="font-semibold text-gray-900">Estimated recovery</h3>
+              <p className="mt-1 text-sm text-gray-600">
+                Most borrowers see 30-100 points of improvement within 1-3 months
+                of consolidation, depending on their overall credit profile and how
+                much of their negative history was student-loan related.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <QuizCTA />
+
+        {/* Important Warnings */}
+        <section data-testid="guide-section-warnings" className="mt-16">
+          <h2 className="text-2xl font-bold text-gray-900">
+            Important Things to Know
+          </h2>
+          <div className="mt-6 space-y-4">
+            <div className="rounded-lg border border-amber-200 bg-amber-50 p-4">
+              <h3 className="font-semibold text-amber-800">
+                Forgiveness progress may reset
+              </h3>
+              <p className="mt-1 text-sm text-amber-700">
+                If you were making progress toward income-driven repayment forgiveness
+                or Public Service Loan Forgiveness (PSLF), consolidation may reset your
+                qualifying payment count. Check with your servicer before consolidating
+                if this applies to you.
+              </p>
+            </div>
+            <div className="rounded-lg border border-amber-200 bg-amber-50 p-4">
+              <h3 className="font-semibold text-amber-800">
+                Interest rate may be slightly higher
+              </h3>
+              <p className="mt-1 text-sm text-amber-700">
+                The consolidation interest rate is the weighted average of your existing
+                rates, rounded up to the nearest one-eighth of a percent. This rounding
+                can result in a slightly higher overall rate.
+              </p>
+            </div>
+            <div className="rounded-lg border border-amber-200 bg-amber-50 p-4">
+              <h3 className="font-semibold text-amber-800">
+                Private loans cannot be consolidated
+              </h3>
+              <p className="mt-1 text-sm text-amber-700">
+                Direct Consolidation Loans are for federal student loans only. If you
+                have private student loans, you would need to refinance them separately
+                through a private lender.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* FAQ */}
+        <section data-testid="guide-section-faq" className="mt-12">
+          <h2 className="text-2xl font-bold text-gray-900">
+            Frequently Asked Questions
+          </h2>
+          <div className="mt-6 divide-y divide-gray-200">
+            {faqs.map((faq, index) => (
+              <div key={index} className="py-6">
+                <h3 className="text-lg font-semibold text-gray-900">
+                  {faq.question}
+                </h3>
+                <p className="mt-3 text-gray-600 leading-7">{faq.answer}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* Related Guides */}
+        <section data-testid="guide-section-related" className="mt-12">
+          <h2 className="text-2xl font-bold text-gray-900">
+            Related Recovery Guides
+          </h2>
+          <div className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <Link
+              href="/guides/ibr-enrollment"
+              data-testid="related-link-ibr"
+              className="rounded-xl border border-gray-200 p-6 hover:border-emerald-300 hover:shadow-md transition-all"
+            >
+              <h3 className="font-semibold text-gray-900">
+                IBR Enrollment Guide
+              </h3>
+              <p className="mt-2 text-sm text-gray-600">
+                After consolidation, enroll in IBR to keep your monthly payments
+                affordable based on your income.
+              </p>
+            </Link>
+            <Link
+              href="/guides/loan-rehabilitation"
+              data-testid="related-link-rehabilitation"
+              className="rounded-xl border border-gray-200 p-6 hover:border-emerald-300 hover:shadow-md transition-all"
+            >
+              <h3 className="font-semibold text-gray-900">
+                Loan Rehabilitation Guide
+              </h3>
+              <p className="mt-2 text-sm text-gray-600">
+                Want the default removed from your credit report? Rehabilitation
+                is the only path that does this.
+              </p>
+            </Link>
+          </div>
+        </section>
+
+        <QuizCTA />
+      </article>
+    </>
+  );
+}

--- a/scorerebound/src/app/guides/loan-rehabilitation/page.tsx
+++ b/scorerebound/src/app/guides/loan-rehabilitation/page.tsx
@@ -1,0 +1,453 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import QuizCTA from "@/components/QuizCTA";
+import FAQSchema, { type FAQItem } from "@/components/FAQSchema";
+
+export const metadata: Metadata = {
+  title:
+    "Student Loan Rehabilitation Guide — Remove Default from Credit Report | ScoreRebound",
+  description:
+    "Complete guide to student loan rehabilitation. Make 9 affordable payments to remove the default from your credit report. Learn eligibility, steps, and credit score impact.",
+  openGraph: {
+    title:
+      "Student Loan Rehabilitation Guide — Remove Default from Credit Report",
+    description:
+      "Make 9 affordable monthly payments to remove the default from your credit report. The only recovery path that erases the default notation.",
+    type: "article",
+    siteName: "ScoreRebound",
+  },
+};
+
+const faqs: FAQItem[] = [
+  {
+    question: "What is student loan rehabilitation?",
+    answer:
+      "Student loan rehabilitation is a one-time opportunity to remove a federal student loan default from your credit report. You agree to make 9 voluntary, on-time monthly payments within 10 consecutive months. The payment amount is calculated based on your income and can be as low as $5 per month.",
+  },
+  {
+    question:
+      "How much are the rehabilitation payments?",
+    answer:
+      "Your rehabilitation payment is calculated as 15% of your discretionary income divided by 12. Discretionary income is the difference between your adjusted gross income and 150% of the poverty guideline. If this calculation results in a very low amount, the minimum payment is $5 per month.",
+  },
+  {
+    question:
+      "Will rehabilitation remove the default from my credit report?",
+    answer:
+      "Yes — this is the unique benefit of rehabilitation over other recovery paths. Once you complete 9 qualifying payments, the default notation is removed from your credit report. However, the individual late payment records that occurred before the default will remain.",
+  },
+  {
+    question: "Can I rehabilitate my loans more than once?",
+    answer:
+      "No. Loan rehabilitation is a one-time opportunity per loan. If you default again after completing rehabilitation, you cannot rehabilitate that loan a second time. Your only options would be consolidation or full repayment.",
+  },
+  {
+    question:
+      "What happens to wage garnishment during rehabilitation?",
+    answer:
+      "Wage garnishment is suspended once you enter a rehabilitation agreement and must stop entirely once rehabilitation is complete. Tax refund offsets may also be stopped or refunded if rehabilitation is completed before the offset is processed.",
+  },
+  {
+    question:
+      "How long does loan rehabilitation take?",
+    answer:
+      "The rehabilitation process requires 9 on-time payments within 10 consecutive months, so it takes approximately 9-10 months from start to finish. After completion, it may take an additional 1-2 months for the default to be removed from your credit report.",
+  },
+];
+
+export default function LoanRehabilitationGuide() {
+  return (
+    <>
+      <FAQSchema faqs={faqs} />
+
+      <article className="mx-auto max-w-4xl px-4 py-16 sm:px-6 lg:px-8">
+        {/* Breadcrumb */}
+        <nav data-testid="guide-breadcrumb" className="mb-8 text-sm text-gray-500">
+          <Link href="/" data-testid="breadcrumb-home" className="hover:text-emerald-700">
+            Home
+          </Link>
+          <span className="mx-2">/</span>
+          <span className="text-gray-900">Loan Rehabilitation Guide</span>
+        </nav>
+
+        {/* Header */}
+        <header data-testid="guide-header">
+          <div className="mb-4 inline-flex items-center rounded-full border border-emerald-200 bg-emerald-50 px-3 py-1 text-sm font-medium text-emerald-700">
+            Recovery Path
+          </div>
+          <h1
+            data-testid="guide-title"
+            className="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl lg:text-5xl"
+          >
+            Student Loan Rehabilitation Guide
+          </h1>
+          <p
+            data-testid="guide-description"
+            className="mt-6 text-lg leading-8 text-gray-600"
+          >
+            Loan rehabilitation is the <strong>only federal program</strong> that removes
+            the default notation from your credit report. By making 9 affordable monthly
+            payments, you can erase the default and start rebuilding your credit. This
+            guide covers everything you need to know.
+          </p>
+        </header>
+
+        {/* Key Stats */}
+        <div
+          data-testid="guide-key-stats"
+          className="my-12 grid grid-cols-1 gap-4 sm:grid-cols-3"
+        >
+          <div className="rounded-xl border border-gray-200 bg-gray-50 p-6 text-center">
+            <p className="text-3xl font-bold text-emerald-600">9</p>
+            <p className="mt-1 text-sm text-gray-600">
+              on-time payments required
+            </p>
+          </div>
+          <div className="rounded-xl border border-gray-200 bg-gray-50 p-6 text-center">
+            <p className="text-3xl font-bold text-emerald-600">$5/mo</p>
+            <p className="mt-1 text-sm text-gray-600">
+              minimum payment possible
+            </p>
+          </div>
+          <div className="rounded-xl border border-gray-200 bg-gray-50 p-6 text-center">
+            <p className="text-3xl font-bold text-emerald-600">50-150 pts</p>
+            <p className="mt-1 text-sm text-gray-600">
+              potential score improvement
+            </p>
+          </div>
+        </div>
+
+        <QuizCTA />
+
+        {/* What is Rehabilitation */}
+        <section data-testid="guide-section-what-is" className="mt-16">
+          <h2 className="text-2xl font-bold text-gray-900">
+            What Is Loan Rehabilitation?
+          </h2>
+          <p className="mt-4 text-gray-600 leading-7">
+            Student loan rehabilitation is a federal program designed to help borrowers
+            recover from default. When you default on federal student loans — typically
+            after 270 days of non-payment — it creates a devastating mark on your credit
+            report that can drop your score by 100 or more points.
+          </p>
+          <p className="mt-4 text-gray-600 leading-7">
+            Rehabilitation gives you one chance to erase that default. You agree to
+            make 9 voluntary, on-time monthly payments within a window of 10
+            consecutive months. The payment amount is based on your income and can be
+            as low as $5 per month. Once you complete the 9 payments, the default
+            notation is removed from all three credit bureaus.
+          </p>
+          <div className="mt-6 rounded-lg border border-emerald-200 bg-emerald-50 p-4">
+            <p className="text-sm text-emerald-800">
+              <strong>Key benefit:</strong> Rehabilitation is the only recovery path
+              that removes the default notation itself from your credit report.
+              Consolidation brings your loans current but the default record stays.
+            </p>
+          </div>
+        </section>
+
+        {/* Eligibility */}
+        <section data-testid="guide-section-eligibility" className="mt-12">
+          <h2 className="text-2xl font-bold text-gray-900">
+            Eligibility Requirements
+          </h2>
+          <ul className="mt-4 space-y-3 text-gray-600">
+            <li className="flex gap-3">
+              <span className="mt-1 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-emerald-100 text-xs font-bold text-emerald-700">
+                1
+              </span>
+              <span>
+                <strong>Your loans must be in default</strong> — rehabilitation is
+                specifically for borrowers who have already defaulted on federal loans.
+              </span>
+            </li>
+            <li className="flex gap-3">
+              <span className="mt-1 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-emerald-100 text-xs font-bold text-emerald-700">
+                2
+              </span>
+              <span>
+                <strong>Federal loans only</strong> — private student loans are not
+                eligible for rehabilitation.
+              </span>
+            </li>
+            <li className="flex gap-3">
+              <span className="mt-1 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-emerald-100 text-xs font-bold text-emerald-700">
+                3
+              </span>
+              <span>
+                <strong>One-time opportunity</strong> — you can only rehabilitate each
+                loan once. If you default again, consolidation is your only option.
+              </span>
+            </li>
+            <li className="flex gap-3">
+              <span className="mt-1 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-emerald-100 text-xs font-bold text-emerald-700">
+                4
+              </span>
+              <span>
+                <strong>Not in active bankruptcy</strong> — you cannot rehabilitate
+                loans that are part of an active bankruptcy proceeding.
+              </span>
+            </li>
+          </ul>
+        </section>
+
+        {/* Step by Step */}
+        <section data-testid="guide-section-steps" className="mt-12">
+          <h2 className="text-2xl font-bold text-gray-900">
+            How to Rehabilitate Your Loans: Step by Step
+          </h2>
+          <div className="mt-8 space-y-8">
+            <div className="flex gap-4">
+              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-emerald-600 text-lg font-bold text-white">
+                1
+              </div>
+              <div>
+                <h3 className="text-lg font-semibold text-gray-900">
+                  Find your loan holder
+                </h3>
+                <p className="mt-2 text-gray-600 leading-7">
+                  If your loans are in default, they may have been transferred to the
+                  Default Resolution Group (DRG) or a collection agency. Log into{" "}
+                  <a
+                    href="https://studentaid.gov"
+                    data-testid="guide-link-studentaid"
+                    className="font-medium text-emerald-600 hover:text-emerald-500"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    studentaid.gov
+                  </a>{" "}
+                  to see your current loan holder, or call the Default Resolution Group
+                  at 1-800-621-3115.
+                </p>
+              </div>
+            </div>
+
+            <div className="flex gap-4">
+              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-emerald-600 text-lg font-bold text-white">
+                2
+              </div>
+              <div>
+                <h3 className="text-lg font-semibold text-gray-900">
+                  Request a rehabilitation agreement
+                </h3>
+                <p className="mt-2 text-gray-600 leading-7">
+                  Contact your loan holder and tell them you want to rehabilitate your
+                  loan. They will calculate your monthly payment based on your income. If
+                  you disagree with the calculated amount, you can request a review.
+                  The minimum payment is $5 per month.
+                </p>
+              </div>
+            </div>
+
+            <div className="flex gap-4">
+              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-emerald-600 text-lg font-bold text-white">
+                3
+              </div>
+              <div>
+                <h3 className="text-lg font-semibold text-gray-900">
+                  Make 9 on-time payments within 10 months
+                </h3>
+                <p className="mt-2 text-gray-600 leading-7">
+                  Payments must be voluntary (not from wage garnishment), made within
+                  20 days of the due date, and for the full agreed-upon amount. You
+                  have 10 consecutive months to make 9 qualifying payments — meaning you
+                  can miss one month and still succeed.
+                </p>
+              </div>
+            </div>
+
+            <div className="flex gap-4">
+              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-emerald-600 text-lg font-bold text-white">
+                4
+              </div>
+              <div>
+                <h3 className="text-lg font-semibold text-gray-900">
+                  Your loan is transferred to a new servicer
+                </h3>
+                <p className="mt-2 text-gray-600 leading-7">
+                  After completing rehabilitation, your loan is transferred from the
+                  default holder back to a regular federal loan servicer (like
+                  MOHELA, Nelnet, or Aidvantage). The default notation is removed
+                  from your credit report.
+                </p>
+              </div>
+            </div>
+
+            <div className="flex gap-4">
+              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-emerald-600 text-lg font-bold text-white">
+                5
+              </div>
+              <div>
+                <h3 className="text-lg font-semibold text-gray-900">
+                  Immediately enroll in an income-driven repayment plan
+                </h3>
+                <p className="mt-2 text-gray-600 leading-7">
+                  Once rehabilitation is complete, enroll in{" "}
+                  <Link
+                    href="/guides/ibr-enrollment"
+                    data-testid="guide-link-ibr"
+                    className="font-medium text-emerald-600 hover:text-emerald-500"
+                  >
+                    Income-Based Repayment (IBR)
+                  </Link>{" "}
+                  or another income-driven plan with your new servicer. Do this right
+                  away — the default payment amount after rehabilitation may be high,
+                  and you do not want to fall behind again.
+                </p>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* Credit Impact */}
+        <section data-testid="guide-section-credit-impact" className="mt-12">
+          <h2 className="text-2xl font-bold text-gray-900">
+            Credit Score Impact of Rehabilitation
+          </h2>
+          <p className="mt-4 text-gray-600 leading-7">
+            Loan rehabilitation delivers the biggest potential credit score improvement
+            of any recovery path because it removes the default notation itself — not
+            just bringing the loan current.
+          </p>
+          <div className="mt-6 space-y-4">
+            <div className="rounded-lg border border-gray-200 p-4">
+              <h3 className="font-semibold text-gray-900">Default removal (major impact)</h3>
+              <p className="mt-1 text-sm text-gray-600">
+                The default notation is removed from all three credit bureaus. This is
+                often the single largest negative item on your report, and removing it
+                can result in a 50-150 point improvement.
+              </p>
+            </div>
+            <div className="rounded-lg border border-gray-200 p-4">
+              <h3 className="font-semibold text-gray-900">Late payments remain (smaller impact)</h3>
+              <p className="mt-1 text-sm text-gray-600">
+                Individual late payment records from before the default will stay on your
+                report for 7 years from the date they occurred. However, they become
+                less impactful over time.
+              </p>
+            </div>
+            <div className="rounded-lg border border-gray-200 p-4">
+              <h3 className="font-semibold text-gray-900">Timeline</h3>
+              <p className="mt-1 text-sm text-gray-600">
+                The full rehabilitation process takes 9-10 months, plus 1-2 months for
+                credit bureau updates. Most borrowers see significant score improvement
+                within 12 months of starting rehabilitation.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <QuizCTA />
+
+        {/* Pros and Cons */}
+        <section data-testid="guide-section-pros-cons" className="mt-16">
+          <h2 className="text-2xl font-bold text-gray-900">
+            Rehabilitation vs. Consolidation
+          </h2>
+          <p className="mt-4 text-gray-600 leading-7">
+            Both rehabilitation and consolidation can resolve a default, but they work
+            differently. Here is how they compare:
+          </p>
+          <div className="mt-6 overflow-x-auto">
+            <table className="w-full text-left text-sm">
+              <thead>
+                <tr className="border-b border-gray-200">
+                  <th className="py-3 pr-4 font-semibold text-gray-900">Feature</th>
+                  <th className="py-3 pr-4 font-semibold text-emerald-700">Rehabilitation</th>
+                  <th className="py-3 font-semibold text-gray-700">Consolidation</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100">
+                <tr>
+                  <td className="py-3 pr-4 text-gray-600">Removes default from credit report</td>
+                  <td className="py-3 pr-4 font-medium text-emerald-700">Yes</td>
+                  <td className="py-3 text-gray-600">No</td>
+                </tr>
+                <tr>
+                  <td className="py-3 pr-4 text-gray-600">Time to complete</td>
+                  <td className="py-3 pr-4 text-gray-600">9-10 months</td>
+                  <td className="py-3 font-medium text-gray-900">1-3 months</td>
+                </tr>
+                <tr>
+                  <td className="py-3 pr-4 text-gray-600">Gets you current immediately</td>
+                  <td className="py-3 pr-4 text-gray-600">No (after 9 payments)</td>
+                  <td className="py-3 font-medium text-gray-900">Yes</td>
+                </tr>
+                <tr>
+                  <td className="py-3 pr-4 text-gray-600">Can be used multiple times</td>
+                  <td className="py-3 pr-4 text-gray-600">No (once per loan)</td>
+                  <td className="py-3 font-medium text-gray-900">Yes</td>
+                </tr>
+                <tr>
+                  <td className="py-3 pr-4 text-gray-600">Minimum payment</td>
+                  <td className="py-3 pr-4 font-medium text-emerald-700">$5/month</td>
+                  <td className="py-3 text-gray-600">Varies by income</td>
+                </tr>
+                <tr>
+                  <td className="py-3 pr-4 text-gray-600">Available for Parent PLUS</td>
+                  <td className="py-3 pr-4 text-gray-600">Limited</td>
+                  <td className="py-3 font-medium text-gray-900">Yes</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        {/* FAQ */}
+        <section data-testid="guide-section-faq" className="mt-12">
+          <h2 className="text-2xl font-bold text-gray-900">
+            Frequently Asked Questions
+          </h2>
+          <div className="mt-6 divide-y divide-gray-200">
+            {faqs.map((faq, index) => (
+              <div key={index} className="py-6">
+                <h3 className="text-lg font-semibold text-gray-900">
+                  {faq.question}
+                </h3>
+                <p className="mt-3 text-gray-600 leading-7">{faq.answer}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* Related Guides */}
+        <section data-testid="guide-section-related" className="mt-12">
+          <h2 className="text-2xl font-bold text-gray-900">
+            Related Recovery Guides
+          </h2>
+          <div className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <Link
+              href="/guides/ibr-enrollment"
+              data-testid="related-link-ibr"
+              className="rounded-xl border border-gray-200 p-6 hover:border-emerald-300 hover:shadow-md transition-all"
+            >
+              <h3 className="font-semibold text-gray-900">
+                IBR Enrollment Guide
+              </h3>
+              <p className="mt-2 text-sm text-gray-600">
+                After rehabilitation, enroll in IBR to keep your payments
+                affordable and avoid defaulting again.
+              </p>
+            </Link>
+            <Link
+              href="/guides/loan-consolidation"
+              data-testid="related-link-consolidation"
+              className="rounded-xl border border-gray-200 p-6 hover:border-emerald-300 hover:shadow-md transition-all"
+            >
+              <h3 className="font-semibold text-gray-900">
+                Consolidation Guide
+              </h3>
+              <p className="mt-2 text-sm text-gray-600">
+                Already used your rehabilitation opportunity? Consolidation can
+                still bring your loans current.
+              </p>
+            </Link>
+          </div>
+        </section>
+
+        <QuizCTA />
+      </article>
+    </>
+  );
+}

--- a/scorerebound/src/app/robots.ts
+++ b/scorerebound/src/app/robots.ts
@@ -1,0 +1,16 @@
+import type { MetadataRoute } from "next";
+
+const BASE_URL = process.env.NEXT_PUBLIC_APP_URL || "https://scorerebound.com";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+        disallow: ["/api/", "/plan/"],
+      },
+    ],
+    sitemap: `${BASE_URL}/sitemap.xml`,
+  };
+}

--- a/scorerebound/src/app/servicers/[slug]/page.tsx
+++ b/scorerebound/src/app/servicers/[slug]/page.tsx
@@ -1,0 +1,482 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import QuizCTA from "@/components/QuizCTA";
+import FAQSchema, { type FAQItem } from "@/components/FAQSchema";
+import { SERVICERS, type ServicerInfo } from "@/lib/servicer-data";
+
+interface ServicerPageData {
+  servicerKey: string;
+  servicer: ServicerInfo;
+  description: string;
+  aboutContent: string[];
+  ibrSteps: string[];
+  rehabSteps: string[];
+  consolidationSteps: string[];
+  faqs: FAQItem[];
+}
+
+const SERVICER_PAGES: Record<string, ServicerPageData> = {
+  mohela: {
+    servicerKey: "mohela",
+    servicer: SERVICERS["mohela"]!,
+    description:
+      "MOHELA (Missouri Higher Education Loan Authority) is the largest federal student loan servicer in the United States. This guide covers how to contact MOHELA, enroll in IBR, start rehabilitation, and recover your credit score.",
+    aboutContent: [
+      "MOHELA is the largest federal student loan servicer, managing the accounts of millions of borrowers. If your loans were previously serviced by FedLoan Servicing (PHEAA), they were likely transferred to MOHELA in 2022.",
+      "MOHELA handles most Public Service Loan Forgiveness (PSLF) accounts and has dedicated teams for income-driven repayment applications. They can process IBR applications by phone, which is often faster than the online portal.",
+      "Many borrowers affected by the post-COVID forbearance credit score drop are serviced by MOHELA. If you missed payments after the forbearance on-ramp ended in late 2024, MOHELA is your primary point of contact for resolution.",
+    ],
+    ibrSteps: [
+      "Log into your MOHELA account at mohela.com or call 1-888-866-4352",
+      "Request to switch to an Income-Based Repayment (IBR) plan",
+      "Provide your most recent tax return or current pay stubs",
+      "MOHELA can process IBR applications by phone — often faster than online",
+      "You can also apply through studentaid.gov and MOHELA will be notified",
+      "Set up autopay for a 0.25% interest rate reduction",
+    ],
+    rehabSteps: [
+      "Call MOHELA at 1-888-866-4352 and select the rehabilitation option",
+      "MOHELA will calculate your monthly rehabilitation payment based on income",
+      "Minimum payment can be as low as $5/month",
+      "Make 9 voluntary, on-time payments within 10 consecutive months",
+      "After completion, the default is removed from your credit report",
+      "Your loan will be assigned to a regular servicer (possibly MOHELA again)",
+    ],
+    consolidationSteps: [
+      "Apply for consolidation at studentaid.gov — not through MOHELA directly",
+      "Select an income-driven repayment plan during the application",
+      "Processing takes 30-60 days",
+      "Your consolidated loan may be assigned to MOHELA or another servicer",
+      "Continue making MOHELA payments until consolidation is complete",
+    ],
+    faqs: [
+      {
+        question: "How do I contact MOHELA about my student loans?",
+        answer:
+          "You can reach MOHELA by phone at 1-888-866-4352 (Monday-Friday, 7am-9pm CT) or online at mohela.com. Log into your account to view your loan details, make payments, and submit repayment plan change requests.",
+      },
+      {
+        question: "Can MOHELA process my IBR application by phone?",
+        answer:
+          "Yes. MOHELA can process income-driven repayment applications by phone, which is often faster than the online process. Have your most recent tax return or pay stubs ready when you call. You can also apply online through studentaid.gov.",
+      },
+      {
+        question: "My loans were transferred to MOHELA from FedLoan. What do I need to do?",
+        answer:
+          "If your loans were transferred from FedLoan Servicing (PHEAA) to MOHELA, your loan terms, balances, and repayment plan remain the same. Create a MOHELA account at mohela.com if you haven't already, and verify that your payment information and autopay settings transferred correctly.",
+      },
+      {
+        question: "Does MOHELA handle Public Service Loan Forgiveness (PSLF)?",
+        answer:
+          "Yes. MOHELA is the primary servicer for PSLF accounts. If you work for a qualifying employer and are making payments under an income-driven plan, submit your PSLF Employment Certification Form through MOHELA to track your qualifying payments.",
+      },
+      {
+        question: "What are MOHELA's customer service hours?",
+        answer:
+          "MOHELA's phone support is available Monday through Friday, 7am to 9pm Central Time, at 1-888-866-4352. Online account access through mohela.com is available 24/7.",
+      },
+    ],
+  },
+  nelnet: {
+    servicerKey: "nelnet",
+    servicer: SERVICERS["nelnet"]!,
+    description:
+      "Nelnet is a major federal student loan servicer with a strong online portal. This guide covers contacting Nelnet, enrolling in IBR, managing your repayment, and recovering your credit score.",
+    aboutContent: [
+      "Nelnet is one of the largest federal student loan servicers in the US, known for its user-friendly online portal and extended customer service hours. They service millions of federal student loan borrowers.",
+      "Nelnet offers a strong online platform for managing your repayment plan, making payments, and applying for income-driven repayment. Their portal lets you see projected payments under different plans before you commit.",
+      "If you fell behind on payments after the COVID forbearance ended, Nelnet's online tools make it straightforward to explore your options and get back on track. They offer autopay enrollment with a 0.25% interest rate discount.",
+    ],
+    ibrSteps: [
+      "Log into your Nelnet account at nelnet.com",
+      "Navigate to Repayment Plans and explore income-driven options",
+      "Nelnet's portal shows projected payments under each plan",
+      "Submit your IDR application online through Nelnet or studentaid.gov",
+      "Provide your most recent tax return or income documentation",
+      "Enroll in auto-debit for a 0.25% interest rate reduction",
+    ],
+    rehabSteps: [
+      "Call Nelnet at 1-888-486-4722 to discuss rehabilitation options",
+      "If your loan is in default, Nelnet will calculate an affordable payment",
+      "Agree to the rehabilitation payment amount (can be as low as $5/month)",
+      "Make 9 on-time payments within 10 consecutive months",
+      "Once complete, the default notation is removed from your credit report",
+      "Immediately enroll in an income-driven plan to keep payments affordable",
+    ],
+    consolidationSteps: [
+      "Apply at studentaid.gov/consolidation — the application is not through Nelnet",
+      "Select which Nelnet-serviced loans you want to consolidate",
+      "Choose an income-driven repayment plan during the application",
+      "Continue making Nelnet payments until consolidation is finalized (30-60 days)",
+      "Your new consolidated loan may be assigned to a different servicer",
+    ],
+    faqs: [
+      {
+        question: "How do I contact Nelnet about my student loans?",
+        answer:
+          "Contact Nelnet by phone at 1-888-486-4722 (Monday-Friday 7am-10pm CT, Saturday 8am-4pm CT) or online at nelnet.com. Their online portal lets you manage your account, view payment history, and change repayment plans.",
+      },
+      {
+        question: "Can I change my repayment plan online through Nelnet?",
+        answer:
+          "Yes. Nelnet's online portal allows you to explore and apply for different repayment plans, including income-driven options. You can see projected payments under each plan before committing. For income-driven plans, you can also apply through studentaid.gov.",
+      },
+      {
+        question: "Does Nelnet offer an auto-debit discount?",
+        answer:
+          "Yes. Nelnet offers a 0.25% interest rate reduction when you enroll in automatic debit payments. This saves you money over time and ensures you never miss a payment — which is critical for credit score recovery.",
+      },
+      {
+        question: "What are Nelnet's customer service hours?",
+        answer:
+          "Nelnet's phone support is available Monday through Friday, 7am to 10pm Central Time, and Saturday 8am to 4pm CT, at 1-888-486-4722. Online access through nelnet.com is available 24/7.",
+      },
+      {
+        question: "My credit score dropped after the COVID forbearance ended. What should I do?",
+        answer:
+          "Contact Nelnet immediately to discuss your options. If you are behind on payments, you may be able to enroll in an income-driven repayment plan like IBR to make payments affordable. If you have already defaulted, ask about rehabilitation or consolidation to resolve the default status.",
+      },
+    ],
+  },
+  aidvantage: {
+    servicerKey: "aidvantage",
+    servicer: SERVICERS["aidvantage"]!,
+    description:
+      "Aidvantage (formerly Navient federal loans) is a federal student loan servicer. This guide covers contacting Aidvantage, enrolling in income-driven repayment, and recovering your credit score.",
+    aboutContent: [
+      "Aidvantage took over the federal student loan portfolio from Navient in December 2021. If you previously had federal loans serviced by Navient, they are now with Aidvantage. Your loan terms, balances, and repayment plan did not change during the transfer.",
+      "Aidvantage supports online applications for income-driven repayment plans and provides tools to manage your account online. They service a significant portion of the federal student loan portfolio.",
+      "If your credit score dropped after the COVID forbearance on-ramp ended, Aidvantage can help you explore options to get back on track. Whether you need IBR enrollment, rehabilitation, or consolidation, contacting Aidvantage is your first step.",
+    ],
+    ibrSteps: [
+      "Log into your Aidvantage account at aidvantage.com",
+      "Navigate to repayment options and review income-driven plans",
+      "Submit an IDR application through aidvantage.com or studentaid.gov",
+      "Provide your most recent tax return or proof of income",
+      "Aidvantage will process your application and notify you of your new payment",
+      "Set up autopay to ensure on-time payments and get a rate reduction",
+    ],
+    rehabSteps: [
+      "Call Aidvantage at 1-800-722-1300 to discuss rehabilitation",
+      "If in default, they will calculate an income-based rehabilitation payment",
+      "Minimum payment can be as low as $5/month",
+      "Make 9 on-time payments within 10 consecutive months",
+      "After completion, the default is removed from your credit report",
+      "Enroll in an income-driven plan immediately after rehabilitation",
+    ],
+    consolidationSteps: [
+      "Apply at studentaid.gov/consolidation — not through Aidvantage directly",
+      "Select which Aidvantage-serviced loans you want to consolidate",
+      "Choose an income-driven repayment plan if your loans are in default",
+      "Continue making payments to Aidvantage until consolidation completes (30-60 days)",
+      "Your new consolidated loan may be assigned to a different servicer",
+    ],
+    faqs: [
+      {
+        question: "How do I contact Aidvantage about my student loans?",
+        answer:
+          "Contact Aidvantage by phone at 1-800-722-1300 (Monday-Friday, 8am-9pm ET) or online at aidvantage.com. You can manage your account, make payments, and apply for repayment plan changes through their online portal.",
+      },
+      {
+        question: "My loans were with Navient. Are they now at Aidvantage?",
+        answer:
+          "If you had federal student loans serviced by Navient, they were transferred to Aidvantage in December 2021. Your loan terms, interest rates, and repayment plan remained the same. Create an Aidvantage account at aidvantage.com to manage your loans.",
+      },
+      {
+        question: "Can I apply for income-driven repayment through Aidvantage?",
+        answer:
+          "Yes. Aidvantage supports online IDR plan applications through their portal. You can also apply through studentaid.gov. Both methods work — use whichever is more convenient. Have your tax return ready to verify income.",
+      },
+      {
+        question: "What are Aidvantage's customer service hours?",
+        answer:
+          "Aidvantage's phone support is available Monday through Friday, 8am to 9pm Eastern Time, at 1-800-722-1300. Online account access through aidvantage.com is available 24/7.",
+      },
+      {
+        question: "Does Aidvantage offer autopay discounts?",
+        answer:
+          "Yes. Like most federal loan servicers, Aidvantage offers a 0.25% interest rate reduction when you enroll in autopay. This saves money and ensures on-time payments, which is the most important factor in credit score recovery.",
+      },
+    ],
+  },
+};
+
+export function generateStaticParams() {
+  return Object.keys(SERVICER_PAGES).map((slug) => ({ slug }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+  const data = SERVICER_PAGES[slug];
+  if (!data) return {};
+
+  return {
+    title: `${data.servicer.shortName} Student Loan Guide — Contact, IBR, Rehabilitation | ScoreRebound`,
+    description: data.description,
+    openGraph: {
+      title: `${data.servicer.shortName} Student Loan Guide — ScoreRebound`,
+      description: data.description,
+      type: "article",
+      siteName: "ScoreRebound",
+    },
+  };
+}
+
+export default async function ServicerPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const data = SERVICER_PAGES[slug];
+
+  if (!data) {
+    notFound();
+  }
+
+  const { servicer, faqs } = data;
+
+  return (
+    <>
+      <FAQSchema faqs={faqs} />
+
+      <article className="mx-auto max-w-4xl px-4 py-16 sm:px-6 lg:px-8">
+        {/* Breadcrumb */}
+        <nav data-testid="servicer-breadcrumb" className="mb-8 text-sm text-gray-500">
+          <Link href="/" data-testid="breadcrumb-home" className="hover:text-emerald-700">
+            Home
+          </Link>
+          <span className="mx-2">/</span>
+          <span className="text-gray-900">{servicer.shortName}</span>
+        </nav>
+
+        {/* Header */}
+        <header data-testid="servicer-header">
+          <div className="mb-4 inline-flex items-center rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm font-medium text-blue-700">
+            Loan Servicer
+          </div>
+          <h1
+            data-testid="servicer-title"
+            className="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl lg:text-5xl"
+          >
+            {servicer.shortName} Student Loan Guide
+          </h1>
+          <p
+            data-testid="servicer-description"
+            className="mt-6 text-lg leading-8 text-gray-600"
+          >
+            {data.description}
+          </p>
+        </header>
+
+        {/* Contact Info */}
+        <div
+          data-testid="servicer-contact-info"
+          className="my-12 rounded-xl border border-gray-200 bg-gray-50 p-6"
+        >
+          <h2 className="text-lg font-semibold text-gray-900">
+            Contact {servicer.shortName}
+          </h2>
+          <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-3">
+            <div>
+              <p className="text-sm font-medium text-gray-500">Phone</p>
+              <p className="mt-1 text-base font-semibold text-gray-900">
+                {servicer.phone}
+              </p>
+            </div>
+            <div>
+              <p className="text-sm font-medium text-gray-500">Hours</p>
+              <p className="mt-1 text-sm text-gray-900">{servicer.hours}</p>
+            </div>
+            <div>
+              <p className="text-sm font-medium text-gray-500">Website</p>
+              <a
+                href={servicer.website}
+                data-testid="servicer-website-link"
+                className="mt-1 inline-block text-sm font-medium text-emerald-600 hover:text-emerald-500"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {servicer.website.replace("https://", "")}
+              </a>
+            </div>
+          </div>
+          {servicer.specialNotes.length > 0 && (
+            <div className="mt-4 border-t border-gray-200 pt-4">
+              <p className="text-sm font-medium text-gray-500">Key Notes</p>
+              <ul className="mt-2 space-y-1">
+                {servicer.specialNotes.map((note, i) => (
+                  <li key={i} className="text-sm text-gray-600">
+                    &bull; {note}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+
+        <QuizCTA />
+
+        {/* About */}
+        <section data-testid="servicer-section-about" className="mt-16">
+          <h2 className="text-2xl font-bold text-gray-900">
+            About {servicer.shortName}
+          </h2>
+          {data.aboutContent.map((paragraph, i) => (
+            <p key={i} className="mt-4 text-gray-600 leading-7">
+              {paragraph}
+            </p>
+          ))}
+        </section>
+
+        {/* IBR Steps */}
+        <section data-testid="servicer-section-ibr" className="mt-12">
+          <h2 className="text-2xl font-bold text-gray-900">
+            How to Enroll in IBR with {servicer.shortName}
+          </h2>
+          <p className="mt-4 text-gray-600 leading-7">
+            Income-Based Repayment caps your monthly payment at 10-15% of your
+            discretionary income. Here is how to enroll through {servicer.shortName}:
+          </p>
+          <ol className="mt-6 space-y-3">
+            {data.ibrSteps.map((step, i) => (
+              <li key={i} className="flex gap-3 text-gray-600">
+                <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-emerald-100 text-xs font-bold text-emerald-700">
+                  {i + 1}
+                </span>
+                <span>{step}</span>
+              </li>
+            ))}
+          </ol>
+          <p className="mt-4 text-sm text-gray-500">
+            For a complete guide, see our{" "}
+            <Link
+              href="/guides/ibr-enrollment"
+              data-testid="servicer-link-ibr-guide"
+              className="font-medium text-emerald-600 hover:text-emerald-500"
+            >
+              IBR Enrollment Guide
+            </Link>
+            .
+          </p>
+        </section>
+
+        {/* Rehabilitation Steps */}
+        <section data-testid="servicer-section-rehab" className="mt-12">
+          <h2 className="text-2xl font-bold text-gray-900">
+            Loan Rehabilitation with {servicer.shortName}
+          </h2>
+          <p className="mt-4 text-gray-600 leading-7">
+            If your loans are in default, rehabilitation removes the default from
+            your credit report after 9 on-time payments:
+          </p>
+          <ol className="mt-6 space-y-3">
+            {data.rehabSteps.map((step, i) => (
+              <li key={i} className="flex gap-3 text-gray-600">
+                <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-emerald-100 text-xs font-bold text-emerald-700">
+                  {i + 1}
+                </span>
+                <span>{step}</span>
+              </li>
+            ))}
+          </ol>
+          <p className="mt-4 text-sm text-gray-500">
+            For a complete guide, see our{" "}
+            <Link
+              href="/guides/loan-rehabilitation"
+              data-testid="servicer-link-rehab-guide"
+              className="font-medium text-emerald-600 hover:text-emerald-500"
+            >
+              Loan Rehabilitation Guide
+            </Link>
+            .
+          </p>
+        </section>
+
+        {/* Consolidation Steps */}
+        <section data-testid="servicer-section-consolidation" className="mt-12">
+          <h2 className="text-2xl font-bold text-gray-900">
+            Consolidation for {servicer.shortName} Borrowers
+          </h2>
+          <p className="mt-4 text-gray-600 leading-7">
+            Consolidation brings defaulted loans current immediately. It is processed
+            through studentaid.gov, not through {servicer.shortName} directly:
+          </p>
+          <ol className="mt-6 space-y-3">
+            {data.consolidationSteps.map((step, i) => (
+              <li key={i} className="flex gap-3 text-gray-600">
+                <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-emerald-100 text-xs font-bold text-emerald-700">
+                  {i + 1}
+                </span>
+                <span>{step}</span>
+              </li>
+            ))}
+          </ol>
+          <p className="mt-4 text-sm text-gray-500">
+            For a complete guide, see our{" "}
+            <Link
+              href="/guides/loan-consolidation"
+              data-testid="servicer-link-consolidation-guide"
+              className="font-medium text-emerald-600 hover:text-emerald-500"
+            >
+              Loan Consolidation Guide
+            </Link>
+            .
+          </p>
+        </section>
+
+        <QuizCTA />
+
+        {/* FAQ */}
+        <section data-testid="servicer-section-faq" className="mt-16">
+          <h2 className="text-2xl font-bold text-gray-900">
+            Frequently Asked Questions about {servicer.shortName}
+          </h2>
+          <div className="mt-6 divide-y divide-gray-200">
+            {faqs.map((faq, index) => (
+              <div key={index} className="py-6">
+                <h3 className="text-lg font-semibold text-gray-900">
+                  {faq.question}
+                </h3>
+                <p className="mt-3 text-gray-600 leading-7">{faq.answer}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* Other Servicers */}
+        <section data-testid="servicer-section-related" className="mt-12">
+          <h2 className="text-2xl font-bold text-gray-900">
+            Other Loan Servicer Guides
+          </h2>
+          <div className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2">
+            {Object.entries(SERVICER_PAGES)
+              .filter(([key]) => key !== slug)
+              .map(([key, otherData]) => (
+                <Link
+                  key={key}
+                  href={`/servicers/${key}`}
+                  data-testid={`related-servicer-${key}`}
+                  className="rounded-xl border border-gray-200 p-6 hover:border-emerald-300 hover:shadow-md transition-all"
+                >
+                  <h3 className="font-semibold text-gray-900">
+                    {otherData.servicer.shortName} Guide
+                  </h3>
+                  <p className="mt-2 text-sm text-gray-600">
+                    Phone: {otherData.servicer.phone}
+                  </p>
+                </Link>
+              ))}
+          </div>
+        </section>
+
+        <QuizCTA />
+      </article>
+    </>
+  );
+}

--- a/scorerebound/src/app/sitemap.ts
+++ b/scorerebound/src/app/sitemap.ts
@@ -1,0 +1,54 @@
+import type { MetadataRoute } from "next";
+
+const BASE_URL = process.env.NEXT_PUBLIC_APP_URL || "https://scorerebound.com";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const now = new Date().toISOString();
+
+  return [
+    {
+      url: BASE_URL,
+      lastModified: now,
+      changeFrequency: "weekly",
+      priority: 1.0,
+    },
+    // Recovery path guides
+    {
+      url: `${BASE_URL}/guides/ibr-enrollment`,
+      lastModified: now,
+      changeFrequency: "monthly",
+      priority: 0.9,
+    },
+    {
+      url: `${BASE_URL}/guides/loan-rehabilitation`,
+      lastModified: now,
+      changeFrequency: "monthly",
+      priority: 0.9,
+    },
+    {
+      url: `${BASE_URL}/guides/loan-consolidation`,
+      lastModified: now,
+      changeFrequency: "monthly",
+      priority: 0.9,
+    },
+    // Servicer-specific guides
+    {
+      url: `${BASE_URL}/servicers/mohela`,
+      lastModified: now,
+      changeFrequency: "monthly",
+      priority: 0.8,
+    },
+    {
+      url: `${BASE_URL}/servicers/nelnet`,
+      lastModified: now,
+      changeFrequency: "monthly",
+      priority: 0.8,
+    },
+    {
+      url: `${BASE_URL}/servicers/aidvantage`,
+      lastModified: now,
+      changeFrequency: "monthly",
+      priority: 0.8,
+    },
+  ];
+}

--- a/scorerebound/src/components/FAQSchema.tsx
+++ b/scorerebound/src/components/FAQSchema.tsx
@@ -1,0 +1,26 @@
+export interface FAQItem {
+  question: string;
+  answer: string;
+}
+
+export default function FAQSchema({ faqs }: { faqs: FAQItem[] }) {
+  const schema = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: faqs.map((faq) => ({
+      "@type": "Question",
+      name: faq.question,
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: faq.answer,
+      },
+    })),
+  };
+
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }}
+    />
+  );
+}

--- a/scorerebound/src/components/QuizCTA.tsx
+++ b/scorerebound/src/components/QuizCTA.tsx
@@ -1,0 +1,25 @@
+import Link from "next/link";
+
+export default function QuizCTA() {
+  return (
+    <section
+      data-testid="guide-quiz-cta"
+      className="my-16 rounded-2xl bg-emerald-50 border border-emerald-200 px-6 py-12 text-center"
+    >
+      <h2 className="text-2xl font-bold text-gray-900 sm:text-3xl">
+        Get Your Personalized Recovery Plan
+      </h2>
+      <p className="mx-auto mt-4 max-w-xl text-lg text-gray-600">
+        Take our free 2-minute quiz to get a step-by-step recovery plan
+        tailored to your specific loan type, servicer, and situation.
+      </p>
+      <Link
+        href="/#quiz"
+        data-testid="guide-quiz-cta-button"
+        className="mt-8 inline-block rounded-lg bg-emerald-600 px-8 py-3 text-base font-semibold text-white shadow-sm hover:bg-emerald-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600"
+      >
+        Start My Free Recovery Plan
+      </Link>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds 6 statically-generated SEO content pages as search funnel entry points
- Three recovery path guides: `/guides/ibr-enrollment`, `/guides/loan-rehabilitation`, `/guides/loan-consolidation`
- Three servicer-specific guides: `/servicers/mohela`, `/servicers/nelnet`, `/servicers/aidvantage`
- Each page has meta title/description, OpenGraph tags, FAQ structured data (JSON-LD), prominent quiz CTAs, cross-links, breadcrumbs, and `data-testid` attributes
- Adds `sitemap.ts` (7 URLs with priorities) and `robots.ts` (blocks `/api/` and `/plan/`)
- Adds shared `FAQSchema` and `QuizCTA` components
- All pages are SSG (static generation) — zero runtime cost
- Version bump to 0.4.1

## Acceptance Criteria

- [x] `/guides/ibr-enrollment` — full guide with quiz CTA
- [x] `/guides/loan-rehabilitation` — full guide with quiz CTA
- [x] `/guides/loan-consolidation` — full guide with quiz CTA
- [x] `/servicers/mohela`, `/servicers/nelnet`, `/servicers/aidvantage` — servicer-specific guides
- [x] Each page: meta title, description, OG tags, FAQ schema
- [x] Each page: prominent quiz CTA
- [x] `sitemap.ts` and `robots.ts`
- [x] All pages SSG (static generation)
- [x] `bun run build` exits 0

## Test plan

- [x] `bun run build` — all 12 routes compile, guides are ○ (static), servicers are ● (SSG)
- [x] `bun run test` — 81 tests pass (6 test files)
- [x] `bun run lint` — no warnings or errors
- [x] `bash scripts/validate-pr.sh scorerebound` — 0 errors, 0 warnings
- [ ] Verify pages render correctly in browser
- [ ] Verify sitemap.xml includes all 7 URLs
- [ ] Verify robots.txt blocks `/api/` and `/plan/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)