### PR TITLE
docs(scorerebound): affiliate program research and signup guide (closes #284)

### DIFF
--- a/scorerebound/docs/affiliate-programs.md
+++ b/scorerebound/docs/affiliate-programs.md
@@ -1,0 +1,265 @@
+# ScoreRebound Affiliate Programs Research
+
+> Last updated: 2026-03-17
+
+ScoreRebound monetizes through affiliate commissions on credit-building and student loan products recommended in personalized recovery plans. This document catalogs researched affiliate programs, their terms, and signup details.
+
+## Priority Tiers
+
+### Tier 1 — High Priority (Sign Up Immediately)
+
+These programs have the best alignment with ScoreRebound's audience (borrowers rebuilding credit after student loan delinquency) and the highest revenue potential.
+
+---
+
+#### 1. SoFi — Student Loan Refinancing
+
+| Field | Details |
+|-------|---------|
+| **Product** | Student loan refinancing |
+| **Commission** | $75-$300 per funded refinance loan (varies by product) |
+| **Cookie Duration** | 30 days |
+| **Annual Cap** | $10,000 per calendar year |
+| **Network** | Impact |
+| **Signup URL** | Apply via [Impact network](https://app.impact.com/) — search "SoFi" |
+| **Approval Time** | ~3-5 business days |
+| **Payout Terms** | Net 30, via Impact |
+| **Why High Priority** | Student loan refinancing is the #1 highest-commission product for our audience. $150/funded loan is exceptional. Borrowers who complete recovery plans are prime refi candidates. |
+
+**Notes:**
+- SoFi offers 5, 7, 10, 15, and 20 year loan terms
+- No application or origination fees, no prepayment penalties
+- Affiliates get access to banners, text links, and tracking dashboard
+- Also available on FlexOffers as secondary network
+
+---
+
+#### 2. Self.inc — Credit Builder Loans
+
+| Field | Details |
+|-------|---------|
+| **Product** | Credit builder loan + secured Visa credit card |
+| **Commission** | $12 per credit builder account creation |
+| **EPC** | $0.53 (FlexOffers data, Feb 2026) |
+| **Cookie Duration** | 30 days |
+| **Network** | FlexOffers (primary), Admitad, PerformCB |
+| **Signup URL** | Apply via [FlexOffers](https://www.flexoffers.com/affiliate-programs/self-inc-affiliate-program/) |
+| **Payout Terms** | Net 30, via FlexOffers |
+| **Why High Priority** | Credit builder loans are the #1 recommendation in every recovery plan. Self.inc is the market leader. High conversion — our users are actively seeking credit-building tools. |
+
+**Notes:**
+- Self.inc pricing starts at $25/month for 24 months ($600 total, builds $600 in savings)
+- Also offers a secured Visa credit card after credit builder account
+- Promotional materials include text links and banners
+- Consider also applying on Admitad and PerformCB for rate comparison
+
+---
+
+#### 3. Experian — Credit Monitoring
+
+| Field | Details |
+|-------|---------|
+| **Product** | Credit monitoring (free + premium tiers) |
+| **Commission** | $6-$31 per signup (varies by product tier: free account $6-$12, paid products $7-$31) |
+| **Cookie Duration** | 10 days (CJ Affiliate) |
+| **Network** | CJ Affiliate (primary), Awin |
+| **Signup URL** | Apply via [CJ Affiliate](https://www.cj.com/) — search "Experian" |
+| **Payout Terms** | Net 30, via CJ |
+| **Why High Priority** | Every recovery plan recommends credit monitoring. Experian is a trusted brand. Recurring commissions on premium upgrades create ongoing revenue. |
+
+**Notes:**
+- Free Experian account signup generates lead commission
+- Premium upgrades (CreditWorks) generate higher per-sale and recurring commissions
+- CJ Affiliate is the primary network; Awin is secondary
+- No minimum payout threshold reported
+
+---
+
+### Tier 2 — Medium Priority (Sign Up This Week)
+
+Good alignment with audience but lower commissions or more competitive approval process.
+
+---
+
+#### 4. Discover — Secured Credit Card
+
+| Field | Details |
+|-------|---------|
+| **Product** | Discover it Secured Credit Card |
+| **Commission** | $40-$100 per approved application (varies by card type) |
+| **Cookie Duration** | 30 days |
+| **Network** | CJ Affiliate, CommissionSoup |
+| **Signup URL** | Apply via [CJ Affiliate](https://www.cj.com/) — search "Discover" |
+| **Payout Terms** | Net 30, via CJ |
+| **Why Medium Priority** | Secured cards are a key recovery tool, but Discover's approval process is stricter than Self.inc. Good brand recognition helps conversion. |
+
+**Notes:**
+- $40-$100 for consumer card approval depending on card type
+- Broader approval criteria than competitors → higher approval rates
+- First-year cashback match (doubles all cashback) is a strong conversion point
+- Note: Discover it Secured cardholders cannot participate in refer-a-friend (affiliate only)
+- Higher commission than Capital One for similar product
+
+---
+
+#### 5. Credit Karma — Free Credit Monitoring
+
+| Field | Details |
+|-------|---------|
+| **Product** | Free credit scores, credit monitoring, financial recommendations |
+| **Commission** | $6-$7 per new signup (varies by network), $4 per reactivation (365+ days inactive), $25 per Money Direct Deposit setup ($750+/mo) |
+| **Cookie Duration** | 30 days |
+| **Network** | Impact ($6/signup), CJ ($0.25/signup), Awin ($7/signup) |
+| **Signup URL** | Apply via [Awin](https://ui.awin.com/merchant-profile/70911) for best rate |
+| **Payout Terms** | Net 30, via respective network |
+| **Why Medium Priority** | Moderate commission ($6-$7) with high conversion — free product, trusted brand. Good entry-level recommendation in recovery plans. Volume play plus Money Direct Deposit upsell ($25). |
+
+**Notes:**
+- Commission rates vary dramatically by network — Awin ($7) vs CJ ($0.25)
+- Always route through highest-paying network (Awin for new signups)
+- Credit Karma also pays $4 for reactivating dormant members (365+ days inactive)
+- US-only program
+- Access to banners, widgets, links, and real-time tracking
+
+---
+
+#### 6. Capital One — Secured Mastercard
+
+| Field | Details |
+|-------|---------|
+| **Product** | Capital One Secured Mastercard |
+| **Commission** | $20-$100 per approved application (varies by card type) |
+| **Cookie Duration** | 30 days |
+| **Network** | CJ Affiliate, FlexOffers |
+| **Signup URL** | Apply via [CJ Affiliate](https://www.cj.com/) — search "Capital One" |
+| **Payout Terms** | Net 30, via CJ |
+| **Why Medium Priority** | Strong brand, wide product range, but secured card commission is on the lower end ($20-40). Higher commissions available for premium cards our audience won't qualify for. |
+
+**Notes:**
+- Commission range is wide because it spans all Capital One cards
+- Secured Mastercard specifically is lower end ($20-40)
+- Good alternative to Discover for users who prefer Mastercard
+
+---
+
+### Tier 3 — Lower Priority (Sign Up When Bandwidth Allows)
+
+Relevant products but either lower commissions, limited availability, or less direct audience fit.
+
+---
+
+#### 7. MoneyLion — Credit Builder Plus
+
+| Field | Details |
+|-------|---------|
+| **Product** | Credit Builder Plus membership + credit builder loan |
+| **Commission** | ~$10 per signup (referral-based, formal affiliate program limited) |
+| **Cookie Duration** | Unknown |
+| **Network** | FlexOffers (program currently not active), VigLink |
+| **Signup URL** | Check [FlexOffers](https://www.flexoffers.com/) periodically |
+| **Payout Terms** | Varies |
+| **Why Lower Priority** | MoneyLion's formal affiliate program appears intermittently available on major networks. Referral program exists but is less scalable than traditional affiliate. |
+
+**Notes:**
+- MoneyLion has a referral program ($10 per Credit Builder Plus signup)
+- Formal affiliate program through FlexOffers reported as not currently active
+- Consider using VigLink as alternative
+- Revisit quarterly — program availability changes
+
+---
+
+#### 8. myFICO — Credit Score Products
+
+| Field | Details |
+|-------|---------|
+| **Product** | FICO score access, credit reports, monitoring |
+| **Commission** | $5-$100 per sale |
+| **EPC** | $117.08 (ShareASale data) |
+| **Cookie Duration** | 30 days |
+| **Network** | ShareASale |
+| **Signup URL** | Apply via [ShareASale](https://www.shareasale.com/) — search "myFICO" |
+| **Payout Terms** | Net 30, via ShareASale |
+| **Why Lower Priority** | Good EPC but lower brand recognition than Experian/Credit Karma. Average sale is $28.51. Supplement to Tier 1 credit monitoring. |
+
+---
+
+## Affiliate Network Summary
+
+| Network | Programs Available | Signup URL |
+|---------|-------------------|------------|
+| **Impact** | SoFi | https://app.impact.com/ |
+| **FlexOffers** | Self.inc, SoFi (secondary) | https://www.flexoffers.com/ |
+| **CJ Affiliate** | Experian, Discover, Capital One, Credit Karma | https://www.cj.com/ |
+| **Awin** | Credit Karma ($7), Experian (secondary) | https://www.awin.com/ |
+| **ShareASale** | myFICO, Credit Firm, National Debt Relief | https://www.shareasale.com/ |
+
+### Recommended Signup Order
+
+1. **Impact** — unlocks SoFi ($150/funded loan, highest commission)
+2. **FlexOffers** — unlocks Self.inc ($12/account, highest volume potential)
+3. **CJ Affiliate** — unlocks Experian, Discover, Capital One (multiple mid-tier programs)
+4. **Awin** — unlocks Credit Karma at best rate ($7 vs $0.25 on CJ)
+5. **ShareASale** — unlocks myFICO and supplementary programs
+
+## Revenue Projections (Conservative)
+
+Assuming 1,000 monthly quiz completions with 5% affiliate click-through rate:
+
+| Program | Monthly Clicks | Est. Conversion | Revenue/Conv | Monthly Revenue |
+|---------|---------------|-----------------|--------------|-----------------|
+| SoFi Refi | 50 | 2% (1 funded) | $150 | $150 |
+| Self.inc | 50 | 10% (5 accounts) | $12 | $60 |
+| Experian | 50 | 15% (7.5 signups) | $12 | $90 |
+| Discover Secured | 50 | 5% (2.5 approved) | $40 | $100 |
+| Credit Karma | 50 | 20% (10 signups) | $7 | $70 |
+| **Total** | | | | **$470/mo** |
+
+At 10,000 monthly quiz completions: **~$4,700/mo**
+
+## Integration Architecture
+
+Affiliate links in ScoreRebound flow through an internal redirect endpoint for click tracking:
+
+```
+User clicks recommendation → /api/affiliate/redirect?program=self&plan_id=123
+→ Log click to affiliate_clicks table
+→ 302 redirect to affiliate URL with tracking parameters
+```
+
+### Environment Variables
+
+All affiliate IDs are stored as environment variables (never hardcoded):
+
+```env
+# Affiliate Program IDs (server-only — never expose to client)
+SELF_AFFILIATE_ID=your-self-inc-affiliate-id
+SOFI_AFFILIATE_ID=your-sofi-affiliate-id
+EXPERIAN_AFFILIATE_ID=your-experian-affiliate-id
+DISCOVER_AFFILIATE_ID=your-discover-affiliate-id
+CREDIT_KARMA_AFFILIATE_ID=your-credit-karma-affiliate-id
+CAPITAL_ONE_AFFILIATE_ID=your-capital-one-affiliate-id
+MONEYLION_AFFILIATE_ID=your-moneylion-affiliate-id
+MYFICO_AFFILIATE_ID=your-myfico-affiliate-id
+```
+
+### Disclosure Requirements
+
+FTC requires clear affiliate disclosure on any page containing affiliate links:
+
+> "ScoreRebound may earn a commission if you sign up for products through our links. This does not affect our recommendations — we only suggest products that genuinely help with credit recovery."
+
+This disclosure must appear:
+- On every page with affiliate links
+- Near the top of the page (not buried in footer)
+- In clear, readable text (not hidden or tiny)
+
+## Action Items
+
+- [x] Research Self.inc, Credit Karma, MoneyLion, SoFi, Experian, Discover programs
+- [x] Document signup URLs, commission rates, cookie durations, payout terms
+- [x] Check CJ Affiliate, ShareASale, Impact for relevant programs
+- [ ] Sign up for Impact (SoFi) — **Owner: bedwards**
+- [ ] Sign up for FlexOffers (Self.inc) — **Owner: bedwards**
+- [ ] Sign up for CJ Affiliate (Experian, Discover) — **Owner: bedwards**
+- [x] Store affiliate IDs in .env.example as placeholders
+- [x] Update CLAUDE.md with integration details


### PR DESCRIPTION
## Summary

- Adds comprehensive affiliate program research documentation at `scorerebound/docs/affiliate-programs.md`
- Covers 8 programs across 5 affiliate networks (Impact, FlexOffers, CJ Affiliate, Awin, ShareASale)
- Includes commission rates, cookie durations, payout terms, signup URLs, and program notes for each
- Provides revenue projections, integration architecture, and FTC disclosure requirements
- Env placeholders for affiliate IDs already exist in `.env.example` (added in prior PRs)
- CLAUDE.md already has affiliate integration details (added in prior PRs)

### Programs Researched

| Tier | Program | Commission | Network |
|------|---------|-----------|---------|
| 1 | SoFi (student loan refi) | $75-$300/funded loan | Impact |
| 1 | Self.inc (credit builder) | $12/account | FlexOffers |
| 1 | Experian (credit monitoring) | $6-$31/signup | CJ Affiliate |
| 2 | Discover (secured card) | $40-$100/approved | CJ Affiliate |
| 2 | Credit Karma (free monitoring) | $7/signup | Awin |
| 2 | Capital One (secured card) | $20-$100/approved | CJ Affiliate |
| 3 | MoneyLion (credit builder) | ~$10/signup | FlexOffers |
| 3 | myFICO (credit scores) | $5-$100/sale | ShareASale |

### Human Action Items

The following signups require bedwards to complete manually:
1. **Impact** — unlocks SoFi ($150/funded loan)
2. **FlexOffers** — unlocks Self.inc ($12/account)
3. **CJ Affiliate** — unlocks Experian, Discover, Capital One

## Test plan

- [x] `bun run build` passes
- [x] `bun run lint` passes
- [x] `bun run test` passes (81 tests)
- [x] `scripts/validate-pr.sh scorerebound` passes (0 errors, 0 warnings)
- [x] Only `scorerebound/docs/` files changed — no scope creep
- [x] Affiliate program details web-validated against FlexOffers, Impact, CJ, Awin, ShareASale

Closes #284

🤖 Generated with [Claude Code](https://claude.com/claude-code)