### PR TITLE
docs(afterloss): affiliate program accounts tracker and env placeholders (closes #297)

### DIFF
--- a/afterloss/.env.example
+++ b/afterloss/.env.example
@@ -5,3 +5,29 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
 # App (AfterLoss is 100% free — no Stripe needed)
 TEST_MODE=false
 NEXT_PUBLIC_APP_URL=http://localhost:3000
+
+# Affiliate Program IDs (server-only — do NOT prefix with NEXT_PUBLIC_)
+# Apply for accounts at each network, then fill in your publisher/affiliate IDs.
+# See docs/affiliate-accounts.md for signup URLs and program details.
+
+# CJ Affiliate (https://signup.cj.com)
+AFTERLOSS_AFFILIATE_CJ_LEGALZOOM_ID=
+AFTERLOSS_AFFILIATE_CJ_NORTON_ID=
+AFTERLOSS_AFFILIATE_CJ_NOLO_ID=
+
+# Impact.com (https://impact.com)
+AFTERLOSS_AFFILIATE_IMPACT_TRUSTANDWILL_ID=
+AFTERLOSS_AFFILIATE_IMPACT_TALKSPACE_ID=
+AFTERLOSS_AFFILIATE_IMPACT_BETTERHELP_ID=
+
+# Yazing (https://yazing.com)
+AFTERLOSS_AFFILIATE_YAZING_ROCKETLAWYER_ID=
+
+# Refersion (https://www.refersion.com)
+AFTERLOSS_AFFILIATE_REFERSION_TITANCASKET_ID=
+
+# Direct programs
+AFTERLOSS_AFFILIATE_AURA_ID=
+AFTERLOSS_AFFILIATE_ETHOS_ID=
+AFTERLOSS_AFFILIATE_EVERLOVED_ID=
+AFTERLOSS_AFFILIATE_FLORISTONE_ID=

--- a/afterloss/docs/affiliate-accounts.md
+++ b/afterloss/docs/affiliate-accounts.md
@@ -1,0 +1,261 @@
+# AfterLoss Affiliate Program Accounts
+
+This document tracks all affiliate program applications, account statuses, link formats, and commission details.
+
+## How to Use
+
+1. Apply at each signup URL below
+2. Update the **Status** column as applications progress: `not applied` → `applied` → `approved` / `rejected`
+3. Once approved, record the affiliate ID and update `afterloss/.env.example` with the env var name
+4. Use the link format column to build affiliate URLs in code (issue #289)
+
+---
+
+## MUST — Top Priority Programs
+
+### Rocket Lawyer
+
+| Field | Value |
+|-------|-------|
+| **Network** | Yazing / VigLink |
+| **Signup URL** | https://yazing.com/affiliate-programs/rocketlawyer-affiliate-program |
+| **Commission** | 30% per sale |
+| **Cookie Duration** | TBD (check on approval) |
+| **Min Payout** | TBD |
+| **Status** | `not applied` |
+| **Account ID** | — |
+| **Link Format** | TBD after approval |
+| **Placement Context** | Estate planning steps, attorney referral steps |
+| **Notes** | Highest commission rate of all programs |
+
+### Trust & Will
+
+| Field | Value |
+|-------|-------|
+| **Network** | Impact.com |
+| **Signup URL** | https://trustandwill.com/affiliate/signup |
+| **Commission** | 20% per sale (avg $80, up to $180 per conversion) |
+| **Cookie Duration** | 30 days |
+| **Min Payout** | TBD |
+| **Status** | `not applied` |
+| **Account ID** | — |
+| **Link Format** | TBD after approval (Impact.com tracking link) |
+| **Placement Context** | Will creation steps, estate planning steps |
+| **Notes** | Strong product-market fit — many survivors need to create/update their own will |
+
+### Talkspace
+
+| Field | Value |
+|-------|-------|
+| **Network** | Impact.com |
+| **Signup URL** | Apply via Impact.com publisher dashboard (search "Talkspace") |
+| **Commission** | $160–170 per referral |
+| **Cookie Duration** | TBD |
+| **Min Payout** | TBD |
+| **Status** | `not applied` |
+| **Account ID** | — |
+| **Link Format** | TBD after approval (Impact.com tracking link) |
+| **Placement Context** | Grief counseling steps, emotional support resources |
+| **Notes** | Highest flat-rate commission. Grief counseling is a natural recommendation. |
+
+### LegalZoom
+
+| Field | Value |
+|-------|-------|
+| **Network** | CJ Affiliate |
+| **Signup URL** | https://signup.cj.com (search "LegalZoom" in advertiser directory) |
+| **Commission** | 15% per sale ($125+ average order) |
+| **Cookie Duration** | 30 days |
+| **Min Payout** | $50 |
+| **Status** | `not applied` |
+| **Account ID** | — |
+| **Link Format** | TBD after approval (CJ tracking link) |
+| **Placement Context** | Estate planning, attorney referral, LLC/business dissolution steps |
+| **Notes** | Well-known brand, high trust. $50 minimum payout threshold. |
+
+### Aura (Identity Theft Protection)
+
+| Field | Value |
+|-------|-------|
+| **Network** | Direct |
+| **Signup URL** | https://www.aura.com/affiliate-program |
+| **Commission** | $65–125 per enrollment |
+| **Cookie Duration** | 60 days |
+| **Min Payout** | TBD |
+| **Status** | `not applied` |
+| **Account ID** | — |
+| **Link Format** | TBD after approval |
+| **Placement Context** | Identity protection steps, fraud alert steps |
+| **Notes** | Perfect product-market fit — 2.5M deceased identities stolen/year. 60-day cookie is generous. |
+
+### Norton LifeLock
+
+| Field | Value |
+|-------|-------|
+| **Network** | CJ Affiliate |
+| **Signup URL** | https://signup.cj.com (search "Norton LifeLock" in advertiser directory) |
+| **Commission** | Up to $110 per sale |
+| **Cookie Duration** | 60 days |
+| **Min Payout** | TBD |
+| **Status** | `not applied` |
+| **Account ID** | — |
+| **Link Format** | TBD after approval (CJ tracking link) |
+| **Placement Context** | Identity protection steps, fraud alert steps |
+| **Notes** | Alternative to Aura for identity theft protection. Well-known brand. |
+
+---
+
+## SHOULD — Secondary Programs
+
+### Nolo
+
+| Field | Value |
+|-------|-------|
+| **Network** | CJ Affiliate |
+| **Signup URL** | https://signup.cj.com/member/signup/publisher/?cid=3906677#/branded |
+| **Commission** | Up to 15% |
+| **Cookie Duration** | 120 days |
+| **Min Payout** | TBD |
+| **Status** | `not applied` |
+| **Account ID** | — |
+| **Link Format** | TBD after approval (CJ tracking link) |
+| **Placement Context** | State probate guides, legal self-help resources |
+| **Notes** | 120-day cookie is ideal for grief users who delay purchases |
+
+### BetterHelp
+
+| Field | Value |
+|-------|-------|
+| **Network** | Impact.com |
+| **Signup URL** | Apply via Impact.com publisher dashboard (search "BetterHelp") |
+| **Commission** | $10–100+ per referral (scales with volume) |
+| **Cookie Duration** | TBD |
+| **Min Payout** | TBD |
+| **Status** | `not applied` |
+| **Account ID** | — |
+| **Link Format** | TBD after approval (Impact.com tracking link) |
+| **Placement Context** | Grief counseling, emotional support steps |
+| **Notes** | Alternative to Talkspace. Commission increases with referral volume. |
+
+### Policygenius
+
+| Field | Value |
+|-------|-------|
+| **Network** | TBD |
+| **Signup URL** | TBD (search affiliate networks) |
+| **Commission** | Up to $120 per sale |
+| **Cookie Duration** | TBD |
+| **Min Payout** | TBD |
+| **Status** | `not applied` |
+| **Account ID** | — |
+| **Link Format** | TBD after approval |
+| **Placement Context** | Life insurance for surviving family members |
+| **Notes** | Life insurance is relevant when survivors realize they need coverage |
+
+### Ethos Life
+
+| Field | Value |
+|-------|-------|
+| **Network** | Direct |
+| **Signup URL** | https://www.ethos.com/affiliate-program/ |
+| **Commission** | $55 per sale |
+| **Cookie Duration** | 7 days |
+| **Min Payout** | TBD |
+| **Status** | `not applied` |
+| **Account ID** | — |
+| **Link Format** | TBD after approval |
+| **Placement Context** | Life insurance for surviving family members |
+| **Notes** | Short 7-day cookie is less ideal than Policygenius |
+
+### Ever Loved
+
+| Field | Value |
+|-------|-------|
+| **Network** | Direct |
+| **Signup URL** | https://everloved.com/for-affiliates/ |
+| **Commission** | 5% funeral products + $50 per fundraiser |
+| **Cookie Duration** | TBD |
+| **Min Payout** | TBD |
+| **Status** | `not applied` |
+| **Account ID** | — |
+| **Link Format** | TBD after approval |
+| **Placement Context** | Funeral planning steps, memorial/fundraising |
+| **Notes** | Lower commission but strong product-market fit for immediate needs |
+
+### Florist One (Funeral Flowers)
+
+| Field | Value |
+|-------|-------|
+| **Network** | Direct |
+| **Signup URL** | https://www.floristone.com/funeral-home-flowers-affiliate-program/ |
+| **Commission** | 20% of flower sales |
+| **Cookie Duration** | TBD |
+| **Min Payout** | TBD |
+| **Status** | `not applied` |
+| **Account ID** | — |
+| **Link Format** | TBD after approval |
+| **Placement Context** | Funeral planning steps |
+| **Notes** | Niche but relevant for immediate funeral needs |
+
+### Titan Casket
+
+| Field | Value |
+|-------|-------|
+| **Network** | Refersion |
+| **Signup URL** | https://titancasket.refersion.com/ |
+| **Commission** | Estimated 5–15% |
+| **Cookie Duration** | TBD |
+| **Min Payout** | TBD |
+| **Status** | `not applied` |
+| **Account ID** | — |
+| **Link Format** | TBD after approval |
+| **Placement Context** | Funeral planning steps |
+| **Notes** | Direct-to-consumer caskets — can save families thousands vs funeral home markup |
+
+---
+
+## Network Accounts Needed
+
+To apply for the programs above, you need publisher accounts on these networks:
+
+| Network | Signup URL | Programs Available |
+|---------|-----------|-------------------|
+| **CJ Affiliate** | https://signup.cj.com | LegalZoom, Norton LifeLock, Nolo |
+| **Impact.com** | https://impact.com | Trust & Will, Talkspace, BetterHelp |
+| **Yazing** | https://yazing.com | Rocket Lawyer |
+| **Refersion** | https://www.refersion.com | Titan Casket |
+
+**Tip:** Apply for CJ Affiliate and Impact.com accounts first — each gives access to multiple programs from a single dashboard.
+
+---
+
+## Programs Confirmed NOT Available
+
+| Program | Reason |
+|---------|--------|
+| **Avvo** | No longer has an affiliate program. Fee-sharing model ruled a violation in NJ and challenged in FL. |
+| **VitalChek** | No formal affiliate program. Link as helpful resource only. |
+| **FreeWill** | Nonprofit partnership model only, not an affiliate option. |
+
+---
+
+## Env Var Naming Convention
+
+Once approved, add affiliate IDs to `.env` using this pattern:
+
+```
+AFTERLOSS_AFFILIATE_{NETWORK}_{PARTNER}_ID=your-id-here
+```
+
+Examples:
+```
+AFTERLOSS_AFFILIATE_CJ_LEGALZOOM_ID=abc123
+AFTERLOSS_AFFILIATE_IMPACT_TRUSTANDWILL_ID=def456
+AFTERLOSS_AFFILIATE_YAZING_ROCKETLAWYER_ID=ghi789
+AFTERLOSS_AFFILIATE_REFERSION_TITANCASKET_ID=stu901
+AFTERLOSS_AFFILIATE_AURA_ID=jkl012
+AFTERLOSS_AFFILIATE_CJ_NORTON_ID=mno345
+AFTERLOSS_AFFILIATE_IMPACT_TALKSPACE_ID=pqr678
+```
+
+These are server-only secrets — do NOT prefix with `NEXT_PUBLIC_`. Affiliate links are constructed server-side to prevent ID scraping.


### PR DESCRIPTION
## Summary
- Add `afterloss/docs/affiliate-accounts.md` documenting all 13 affiliate programs with signup URLs, commission rates, cookie durations, and placement contexts
- Update `.env.example` with placeholder env vars grouped by network (CJ, Impact, Yazing, Refersion, Direct)
- Fix Titan Casket env var naming: `AFTERLOSS_AFFILIATE_REFERSION_TITANCASKET_ID` (per `{NETWORK}_{PARTNER}` convention)

## Context
Clean cherry-pick of commit `478d2bd` from PR #301. PR #301 was blocked due to issue #290 commit contamination (deploy workflows, SEO files across 5 products). This PR contains ONLY the afterloss affiliate docs — 2 files, 287 insertions.

Supersedes #301.

## Test plan
- [ ] Verify only afterloss files are changed (no cross-product contamination)
- [ ] Verify env var naming follows `{NETWORK}_{PARTNER}` convention
- [ ] Verify docs match .env.example entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)