### PR TITLE
docs(afterloss): affiliate revenue model research — 26 partners

### DIFF
--- a/afterloss/docs/revenue-model.md
+++ b/afterloss/docs/revenue-model.md
@@ -1,0 +1,510 @@
+# AfterLoss Revenue Model — Affiliate Program Research
+
+> **Last Updated:** March 2026
+> **Status:** Research complete. Ready for implementation.
+> **Revenue Model:** 100% free product. Revenue from tasteful, contextual affiliate referrals.
+
+## Table of Contents
+
+1. [Revenue Philosophy](#revenue-philosophy)
+2. [Estate Attorney & Legal Services](#estate-attorney--legal-services)
+3. [Grief Counseling & Mental Health](#grief-counseling--mental-health)
+4. [Life Insurance](#life-insurance)
+5. [Funeral Products & Services](#funeral-products--services)
+6. [Programs NOT Available](#programs-not-available)
+7. [Affiliate Network Summary](#affiliate-network-summary)
+8. [Implementation Priority](#implementation-priority)
+9. [Placement Strategy](#placement-strategy)
+
+---
+
+## Revenue Philosophy
+
+AfterLoss is **100% free, forever**. Users never pay us anything. Revenue comes exclusively from affiliate partnerships that are:
+
+- **Contextual** — shown only at checklist steps where the service is genuinely useful
+- **Clearly labeled** — always marked as "Sponsored" or "Partner recommendation"
+- **Non-intrusive** — never interrupt the user's workflow or grief process
+- **Genuinely helpful** — we only recommend services we'd recommend to a friend
+
+The trust model: a free tool builds goodwill, affiliate referrals feel organic because they ARE organic — users need these services, we just make it easier to find good ones.
+
+---
+
+## Estate Attorney & Legal Services
+
+### Tier 1 — Primary Partners
+
+#### Rocket Lawyer
+
+| Detail | Value |
+|--------|-------|
+| **Commission** | 30% per sale (via Yazing); 24% (via FlexOffers) |
+| **Cookie Duration** | 30 days |
+| **Network** | Yazing (best rate), FlexOffers, VigLink/Sovrn |
+| **Signup** | rocketlawyer.com/affiliate-partner.rl |
+| **Why #1** | Highest commission rate (30%) among legal affiliates. Full estate planning suite: wills, trusts, power of attorney, living wills. |
+| **Placement** | Estate planning steps, will creation, power of attorney, trust setup |
+
+#### Trust & Will
+
+| Detail | Value |
+|--------|-------|
+| **Commission** | 20% per plan sold (via Impact direct); 10% via sub-networks |
+| **Cookie Duration** | 30 days |
+| **Minimum Payout** | $10 (Impact default) |
+| **Network** | Impact.com (primary — apply direct for 20% rate) |
+| **Signup** | trustandwill.com/affiliate-program |
+| **Products** | Will Plan, Trust Plan, Young Adult Plan |
+| **Why #2** | Estate-specific product, strong brand, lowest minimum payout ($10). Average sale $80-$180. |
+| **Placement** | Will creation, trust setup, estate planning checklist steps |
+
+#### LegalZoom
+
+| Detail | Value |
+|--------|-------|
+| **Commission** | 15% per sale ($125+ per sale typical) |
+| **Cookie Duration** | 30 days (last-click attribution) |
+| **Minimum Payout** | $50 (direct deposit), $100 (check) |
+| **Network** | CJ Affiliate (Commission Junction) |
+| **Signup** | legalzoom.com/affiliates or via CJ |
+| **Payment** | Monthly — check, direct deposit, Payoneer |
+| **Restrictions** | No coupon sites, no paid ads; must be genuine endorsements |
+| **Placement** | Attorney referral, estate planning, business formation for estate |
+
+#### Nolo
+
+| Detail | Value |
+|--------|-------|
+| **Commission** | 15% base (FlexOffers); tiered on Awin: 25% base, 30% at $500+/mo, 32.5% at $1K+/mo, 35% at $2K+/mo |
+| **Cookie Duration** | 120 days (FlexOffers) / 30 days (Awin) |
+| **Minimum Payout** | $25 |
+| **Network** | Awin (merchant ID 21102), FlexOffers |
+| **Why Important** | 120-day cookie is the longest of any partner. Grief users often delay purchasing — this accommodates their timeline. Products include legal forms, DIY guides, estate planning books. |
+| **Placement** | State probate guides (deep integration), legal self-help, DIY estate settlement |
+
+### Revenue Estimate (Legal)
+
+| Partner | Avg Sale | Commission | Est. Monthly Conversions | Est. Monthly Revenue |
+|---------|----------|------------|--------------------------|----------------------|
+| Rocket Lawyer | $40/mo | 30% ($12) | 50 | $600 |
+| Trust & Will | $120 one-time | 20% ($24) | 30 | $720 |
+| LegalZoom | $150 one-time | 15% ($22.50) | 20 | $450 |
+| Nolo | $30 avg | 25% ($7.50) | 40 | $300 |
+| **Total** | | | **140** | **$2,070/mo** |
+
+---
+
+## Grief Counseling & Mental Health
+
+### Tier 1 — Primary Partners
+
+#### BetterHelp
+
+| Detail | Value |
+|--------|-------|
+| **Commission** | $10-$150+ per referral (CPA). Most affiliates: $10-$40. High-volume: $100-$150+ |
+| **Cookie Duration** | 30 days |
+| **Minimum Payout** | $100 |
+| **Network** | Impact (primary), ShareASale, Skimlinks/Sovrn |
+| **Payment** | Monthly (Net-30 to Net-60) — check, wire, PayPal, direct deposit |
+| **Grief Fit** | Excellent — dedicated grief counseling category with bereavement specialists |
+| **Placement** | Emotional support steps, grief resources, "take care of yourself" prompts |
+
+#### Talkspace
+
+| Detail | Value |
+|--------|-------|
+| **Commission** | $12-$170 per sale (varies by network/tier) |
+| **Cookie Duration** | 30 days (Impact); 3 days (FlexOffers) |
+| **Network** | Impact (primary), FlexOffers, Sovrn/Skimlinks |
+| **Grief Fit** | Excellent — dedicated grief counseling page with bereavement therapists |
+| **Placement** | Grief counseling steps, emotional support, therapy recommendations |
+
+#### Online-Therapy.com
+
+| Detail | Value |
+|--------|-------|
+| **Commission** | $150 per signup (flat rate); higher rates negotiable for volume |
+| **Cookie Duration** | 90 days (best in class for counseling) |
+| **Network** | Self-managed |
+| **Signup** | online-therapy.com/affiliate.php |
+| **Contact** | affiliate@online-therapy.com for custom terms |
+| **Referred User Benefit** | 20% off first month |
+| **Why Notable** | Highest flat-rate commission ($150) + longest cookie (90 days). Grief users delay — 90-day cookie accommodates this. |
+| **Placement** | Therapy recommendations, emotional support sections |
+
+### Tier 2 — Secondary Partners
+
+#### Grief Works (by Julia Samuel)
+
+| Detail | Value |
+|--------|-------|
+| **Commission** | 10% per qualifying subscription sale |
+| **Cookie Duration** | 30 days |
+| **Network** | Self-managed (Illume Apps) |
+| **Signup** | illumeapps.com/griefworks/affiliate/ |
+| **Contact** | linda@illumeapps.com |
+| **Why Notable** | Only 100% grief-specific product with an affiliate program. App/course by psychotherapist Julia Samuel MBE. Lower commission but perfect topical alignment. |
+| **Placement** | Grief resources, self-help recommendations, coping tools |
+
+#### Calmerry
+
+| Detail | Value |
+|--------|-------|
+| **Commission** | $150 per signup |
+| **Cookie Duration** | 45 days |
+| **Network** | Self-managed |
+| **Signup** | calmerry.com/affiliate/ |
+| **Placement** | Alternative to BetterHelp/Talkspace in therapy recommendations |
+
+#### Cerebral
+
+| Detail | Value |
+|--------|-------|
+| **Commission** | $12 per account signup (CPL model) |
+| **Cookie Duration** | 15 days |
+| **Network** | Impact |
+| **Note** | Focuses on anxiety/depression medication management. Relevant for grief-related depression but less direct fit than therapy platforms. |
+
+#### Headspace
+
+| Detail | Value |
+|--------|-------|
+| **Commission** | ~20% on first-year subscription |
+| **Cookie Duration** | 45 days |
+| **Minimum Payout** | $50 |
+| **Network** | FlexOffers |
+| **Placement** | Meditation/mindfulness recommendations, supplementary to therapy |
+
+#### Comfort Connects (Memorial Jewelry)
+
+| Detail | Value |
+|--------|-------|
+| **Commission** | 10% per sale |
+| **Network** | Self-managed |
+| **Signup** | comfortconnects.com/affiliate-program/ |
+| **User Benefit** | Affiliate username becomes a 5% off coupon |
+| **Placement** | Memorial/remembrance steps, grief keepsake recommendations |
+
+### Revenue Estimate (Counseling)
+
+| Partner | Commission | Est. Monthly Conversions | Est. Monthly Revenue |
+|---------|------------|--------------------------|----------------------|
+| BetterHelp | $30 avg | 60 | $1,800 |
+| Talkspace | $50 avg | 30 | $1,500 |
+| Online-Therapy.com | $150 flat | 15 | $2,250 |
+| Grief Works | $5 avg | 20 | $100 |
+| Calmerry | $150 flat | 10 | $1,500 |
+| **Total** | | **135** | **$7,150/mo** |
+
+---
+
+## Life Insurance
+
+### Tier 1 — Primary Partners
+
+#### Bestow
+
+| Detail | Value |
+|--------|-------|
+| **Commission** | $25-$40 per completed application (pay-per-lead) |
+| **Cookie Duration** | 30 days |
+| **Network** | Impact Radius (primary), FlexOffers (secondary) |
+| **Signup** | bestow.com/affiliate |
+| **Features** | No medical exam required. Custom landing pages provided. |
+| **Why #1** | Best commission per lead, easy application process for users, strong brand. No-exam policies reduce friction for grief-stricken users. |
+| **Placement** | "Protect your family" steps, insurance review checklist items |
+
+#### Ladder Life
+
+| Detail | Value |
+|--------|-------|
+| **Commission** | Up to $75 per sale |
+| **Cookie Duration** | 60 days |
+| **Network** | CJ Affiliate |
+| **Signup** | ladderlife.com/affiliates |
+| **Features** | Flexible term life that customers can adjust over time |
+| **Why Notable** | Highest per-sale commission ($75) + longest cookie (60 days) among insurance partners |
+| **Placement** | Insurance review steps, family protection recommendations |
+
+#### Ethos Life
+
+| Detail | Value |
+|--------|-------|
+| **Commission** | $20-$55 per lead |
+| **Cookie Duration** | 7 days |
+| **Network** | Impact Radius |
+| **Signup** | ethos.com/affiliate-program/ |
+| **Features** | Dedicated affiliate manager, marketing assets provided |
+| **Placement** | Life insurance recommendations, family financial planning |
+
+### Tier 2 — Secondary Partners
+
+#### Policygenius
+
+| Detail | Value |
+|--------|-------|
+| **Commission** | $4.80-$120 per sale (varies by policy type) |
+| **Cookie Duration** | 5 days |
+| **Network** | FlexOffers |
+| **Note** | Short cookie duration (5 days) is a disadvantage for grief users who delay. Best for comparison/research content. |
+
+#### Haven Life
+
+| Detail | Value |
+|--------|-------|
+| **Commission** | $24 flat fee per term account creation |
+| **Cookie Duration** | 7 days |
+| **Network** | affiliaXe (network availability may be in flux) |
+| **Note** | Backed by MassMutual. Also has refer-a-friend ($50 Amazon gift card). |
+
+### Revenue Estimate (Insurance)
+
+| Partner | Commission | Est. Monthly Conversions | Est. Monthly Revenue |
+|---------|------------|--------------------------|----------------------|
+| Bestow | $32 avg | 25 | $800 |
+| Ladder | $75 per sale | 10 | $750 |
+| Ethos | $35 avg | 15 | $525 |
+| **Total** | | **50** | **$2,075/mo** |
+
+---
+
+## Funeral Products & Services
+
+### Tier 1 — Primary Partners
+
+#### Ever Loved
+
+| Detail | Value |
+|--------|-------|
+| **Commission** | 5% on funeral products; $50 per fundraising referral; $1 per memorial website |
+| **Network** | Self-managed |
+| **Signup** | everloved.com/for-affiliates/ |
+| **Features** | Covers funeral products, fundraising, and memorial websites. Affiliate dashboard with analytics. |
+| **Why #1** | Multi-product commissions across the full funeral planning lifecycle. Mission-aligned — their 5% fee finances free memorial sites. |
+| **Placement** | Funeral planning steps, memorial creation, fundraising recommendations |
+
+#### Titan Casket
+
+| Detail | Value |
+|--------|-------|
+| **Commission** | Not publicly disclosed (apply to see rates) |
+| **Cookie Duration** | Not publicly disclosed |
+| **Network** | Refersion |
+| **Signup** | titancasket.refersion.com |
+| **Referral Program** | Also offers $50 Amazon gift card per purchase referral |
+| **Restrictions** | No paid digital advertising by affiliates |
+| **Why Notable** | Direct-to-consumer caskets at significant savings vs funeral homes. Strong consumer value proposition. |
+| **Placement** | Casket/funeral product shopping steps |
+
+#### After.com (Cremation Plans)
+
+| Detail | Value |
+|--------|-------|
+| **Commission** | 10% on all referral sales |
+| **Network** | CJ Affiliate |
+| **Signup** | after.com/affiliate |
+| **Features** | Pre-purchased cremation plans |
+| **Placement** | Cremation planning steps, funeral arrangement alternatives |
+
+### Tier 2 — Niche Partners
+
+#### Miracle Memorial (Cremation Jewelry)
+
+| Detail | Value |
+|--------|-------|
+| **Commission** | 40% for retailers/funeral homes; 10-15% for content affiliates |
+| **Network** | Self-managed |
+| **Signup** | miraclememorial.com/affiliateInfo.asp |
+| **Why Notable** | Very high commission rate (up to 40%). Memorial jewelry from ashes/hair. |
+| **Placement** | Memorialization steps, keepsake recommendations |
+
+#### Pulvis Art Urns
+
+| Detail | Value |
+|--------|-------|
+| **Commission** | 8% |
+| **Avg Order Value** | $400+ |
+| **Network** | Self-managed |
+| **Signup** | pulvisurns.com/pages/affiliate-program |
+| **Placement** | Urn selection, cremation aftercare steps |
+
+#### Floristone (Funeral Flowers)
+
+| Detail | Value |
+|--------|-------|
+| **Commission** | 10-20% (20% when flowers + trees purchased together) |
+| **Network** | Self-managed |
+| **Placement** | Funeral arrangement steps, sympathy gifts |
+
+### Pending Investigation
+
+#### VitalChek (Death Certificates)
+
+| Detail | Value |
+|--------|-------|
+| **Program Type** | Preferred Vendor Program (B2B partnership, requires 100K+ monthly uniques) |
+| **Contact** | partnerlinks@vitalchek.com |
+| **Status** | Not a standard affiliate program. Worth pursuing once traffic reaches 100K/mo. |
+| **Note** | Exclusive online partner of 450+ government agencies for vital records. Would be high-value if partnership secured. |
+
+### Revenue Estimate (Funeral)
+
+| Partner | Commission | Est. Monthly Conversions | Est. Monthly Revenue |
+|---------|------------|--------------------------|----------------------|
+| Ever Loved | $15 avg | 30 | $450 |
+| Titan Casket | $50 est | 5 | $250 |
+| After.com | 10% (~$80) | 8 | $640 |
+| Miracle Memorial | $30 avg | 10 | $300 |
+| **Total** | | **53** | **$1,640/mo** |
+
+---
+
+## Programs NOT Available
+
+These were researched and found to be unavailable for affiliate monetization:
+
+| Service | Status | Details |
+|---------|--------|---------|
+| **Avvo** | No affiliate program | Fee-sharing model ruled violation in NJ (June 2017) and challenged in FL. Avvo Legal Services shut down July 31, 2018. Ethics opinions in 8 states (NJ, NY, OH, PA, SC, UT, VA, IN). |
+| **FindLaw** | B2B referral only | $100 gift card for referring law firms to buy FindLaw marketing products. Not consumer-facing affiliate. |
+| **Bar Associations** | Closed system | ABA Model Rule 7.2 prohibits referral fees to non-lawyers. Programs are attorney-to-service only. |
+| **7 Cups** | No commissions | Free peer support platform. Gamified referral "clicks" only, no monetary compensation. |
+| **GriefShare** | Church ministry model | Materials sold to churches who host groups. No individual affiliate program. |
+| **FuneralWise** | Program redesign | Agent program currently paused, not accepting applications. |
+| **Parting.com** | No affiliate program | Funeral home price comparison site. No standard affiliate program for publishers. |
+
+---
+
+## Affiliate Network Summary
+
+Most partners use a small number of networks. Consolidating on these simplifies management:
+
+| Network | Partners | Priority |
+|---------|----------|----------|
+| **Impact.com** | Trust & Will, BetterHelp, Talkspace, Cerebral, Bestow, Ethos | **Primary** — most partners, single dashboard |
+| **CJ Affiliate** | LegalZoom, Ladder Life, After.com | **Secondary** — three strong partners |
+| **Awin** | Nolo (tiered commissions up to 35%) | **Tertiary** — one partner but best tiered rates |
+| **Self-managed** | Online-Therapy.com, Grief Works, Calmerry, Ever Loved, Comfort Connects, Miracle Memorial, Pulvis Art Urns | Apply individually |
+| **Refersion** | Titan Casket | Apply individually |
+| **FlexOffers** | Rocket Lawyer (24%), various secondary | **Optional** — lower rates than direct |
+| **Yazing** | Rocket Lawyer (30%) | Best rate for Rocket Lawyer specifically |
+
+**Recommendation:** Start with **Impact.com** (6 partners) + **CJ Affiliate** (3 partners) = 9 partners from 2 dashboards.
+
+---
+
+## Implementation Priority
+
+Ranked by revenue potential x implementation effort x user journey fit:
+
+### Phase 1 — Launch Partners (implement first)
+
+| Priority | Partner | Category | Why First |
+|----------|---------|----------|-----------|
+| P0 | BetterHelp | Grief Counseling | Highest volume opportunity. Every user needs emotional support. |
+| P0 | Trust & Will | Estate Planning | Direct product fit. Users need wills/trusts during estate settlement. |
+| P0 | Nolo | Legal Self-Help | 120-day cookie accommodates grief timeline. Integrates into state probate guides. |
+| P0 | Ever Loved | Funeral Services | Multi-product fit across funeral planning lifecycle. |
+
+### Phase 2 — Revenue Expansion
+
+| Priority | Partner | Category | Why Second |
+|----------|---------|----------|------------|
+| P1 | Online-Therapy.com | Therapy | Highest flat commission ($150) + 90-day cookie |
+| P1 | Rocket Lawyer | Legal | 30% commission, broad legal services |
+| P1 | Bestow | Life Insurance | No-exam policies, low friction for users |
+| P1 | Ladder Life | Life Insurance | Highest insurance commission ($75), 60-day cookie |
+
+### Phase 3 — Long Tail
+
+| Priority | Partner | Category | Why Third |
+|----------|---------|----------|-----------|
+| P2 | Talkspace | Therapy | Alternative to BetterHelp for A/B testing |
+| P2 | LegalZoom | Legal | Strong brand, lower commission than alternatives |
+| P2 | After.com | Cremation | 10% on cremation plans |
+| P2 | Titan Casket | Caskets | Consumer savings narrative |
+| P2 | Calmerry | Therapy | $150 flat, 45-day cookie |
+| P3 | Grief Works | Grief App | Perfect fit, low commission |
+| P3 | Miracle Memorial | Jewelry | High commission, niche |
+| P3 | Headspace | Meditation | Supplementary, not primary |
+
+---
+
+## Placement Strategy
+
+Affiliate recommendations appear ONLY at relevant checklist steps. Never in headers, sidebars, or interstitials.
+
+### By Checklist Timeline
+
+#### First 24 Hours
+- **Grief counseling**: BetterHelp, Talkspace, Online-Therapy.com
+- **Funeral planning**: Ever Loved (memorial website, fundraising)
+- **Funeral products**: Titan Casket, Floristone (funeral flowers)
+
+#### First Week
+- **Death certificates**: VitalChek (when partnership secured)
+- **Legal help**: Rocket Lawyer, LegalZoom (for immediate legal questions)
+- **Grief support**: Grief Works app, Headspace (meditation)
+- **Memorial products**: Comfort Connects (keepsakes), Miracle Memorial (cremation jewelry)
+
+#### First Month
+- **Estate planning**: Trust & Will (will creation/updates), Nolo (DIY guides)
+- **Probate guidance**: Nolo (state-specific guides), LegalZoom (attorney referral)
+- **Life insurance review**: Bestow, Ladder Life, Ethos (for surviving family)
+- **Cremation planning**: After.com
+
+#### First 3 Months
+- **Ongoing therapy**: BetterHelp, Talkspace (subscription renewal)
+- **Estate settlement**: Rocket Lawyer (document templates), Nolo (legal forms)
+
+#### First Year
+- **Long-term planning**: Trust & Will (trust setup), Ladder Life (policy review)
+- **Tax preparation**: Nolo (tax guides), LegalZoom (CPA referral)
+
+### Display Format
+
+```
++---------------------------------------------+
+| Helpful Resource                            |
+|                                             |
+| Many families find professional grief       |
+| counseling helpful during this time.        |
+| BetterHelp connects you with licensed       |
+| therapists who specialize in grief.         |
+|                                             |
+| [Learn More]                                |
+|                                             |
+| Partner recommendation - Why we suggest this|
++---------------------------------------------+
+```
+
+- Soft, warm colors (never red CTAs or urgency language)
+- "Partner recommendation" label always visible
+- "Why we suggest this" link explains our affiliate relationship
+- Maximum 1 recommendation per checklist section
+- Never auto-play, pop-up, or interrupt the user's flow
+
+---
+
+## Total Revenue Projection
+
+| Category | Est. Monthly Revenue | Est. Annual Revenue |
+|----------|----------------------|---------------------|
+| Legal Services | $2,070 | $24,840 |
+| Grief Counseling | $7,150 | $85,800 |
+| Life Insurance | $2,075 | $24,900 |
+| Funeral Products | $1,640 | $19,680 |
+| **Total** | **$12,935/mo** | **$155,220/yr** |
+
+These estimates assume moderate traffic (50K monthly uniques). Revenue scales linearly with traffic and improves with conversion optimization.
+
+---
+
+## Next Steps
+
+See follow-up GitHub issues:
+- **#302** — Embed Phase 1 affiliate links (BetterHelp, Trust & Will, Nolo, Ever Loved)
+- **#303** — Embed Phase 2 affiliate links (Online-Therapy.com, Rocket Lawyer, Bestow, Ladder Life)
+- **#304** — Affiliate click tracking infrastructure and analytics dashboard


### PR DESCRIPTION
## Summary
- Comprehensive affiliate revenue model research for AfterLoss
- 26 partners across 4 categories: estate attorneys, grief counseling, life insurance, funeral products
- Commission rates, cookie durations, network info, and placement strategy
- Phased implementation plan (P0 → P1 → P2 → P3)
- Projected $12.9K/mo at 50K monthly uniques

## Test plan
- [x] Doc-only change, no code impact
- [ ] Claude code review
- [ ] Gemini code review

🤖 Generated with [Claude Code](https://claude.com/claude-code)