### PR TITLE
feat(scorerebound): route email affiliate links through tracking endpoint

### DIFF
--- a/scorerebound/package.json
+++ b/scorerebound/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scorerebound",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/scorerebound/src/lib/affiliates.test.ts
+++ b/scorerebound/src/lib/affiliates.test.ts
@@ -127,6 +127,11 @@ describe("getAffiliateSlugs", () => {
     expect(slugs).toContain("discover_secured");
     expect(slugs).toContain("capital_one_secured");
     expect(slugs).toContain("credit_karma");
-    expect(slugs.length).toBe(6);
+    expect(slugs).toContain("moneylion");
+    expect(slugs).toContain("chime");
+    expect(slugs).toContain("capital_one_creditwise");
+    expect(slugs).toContain("earnest");
+    expect(slugs).toContain("splash");
+    expect(slugs.length).toBe(11);
   });
 });

--- a/scorerebound/src/lib/affiliates.ts
+++ b/scorerebound/src/lib/affiliates.ts
@@ -98,6 +98,61 @@ export const AFFILIATE_PRODUCTS: Record<string, AffiliateProduct> = {
     whyRecommended:
       "Once your score recovers, refinancing can save thousands in interest.",
   },
+  moneylion: {
+    slug: "moneylion",
+    name: "MoneyLion Credit Builder Plus",
+    category: "credit_builder",
+    description:
+      "0% APR credit-builder loan with credit monitoring included.",
+    ctaText: "Start Building Credit",
+    baseUrl: "https://www.moneylion.com/",
+    whyRecommended:
+      "Combines credit building and monitoring in a single product.",
+  },
+  chime: {
+    slug: "chime",
+    name: "Chime Credit Builder Card",
+    category: "secured_card",
+    description:
+      "Secured card with no annual fee, no interest, no credit check.",
+    ctaText: "Get Started",
+    baseUrl: "https://www.chime.com/credit-builder/",
+    whyRecommended:
+      "Build credit with everyday purchases — no risk of interest charges.",
+  },
+  capital_one_creditwise: {
+    slug: "capital_one_creditwise",
+    name: "Capital One CreditWise",
+    category: "credit_monitoring",
+    description:
+      "Free TransUnion score and credit simulator. No Capital One account needed.",
+    ctaText: "Check Your Score Free",
+    baseUrl: "https://www.capitalone.com/creditwise/",
+    whyRecommended:
+      "Free credit monitoring and score simulator to track recovery progress.",
+  },
+  earnest: {
+    slug: "earnest",
+    name: "Earnest Student Loan Refinancing",
+    category: "refinancing",
+    description:
+      "Customize your monthly payment. Skip a payment once a year. Rates from 4.49% APR.",
+    ctaText: "Check Your Rate",
+    baseUrl: "https://www.earnest.com/student-loan-refinancing/",
+    whyRecommended:
+      "Flexible repayment options let you customize your monthly payment amount.",
+  },
+  splash: {
+    slug: "splash",
+    name: "Splash Financial",
+    category: "refinancing",
+    description:
+      "Compare rates from multiple lenders in one application. Quick prequalification.",
+    ctaText: "Compare Rates",
+    baseUrl: "https://www.splashfinancial.com/",
+    whyRecommended:
+      "One application lets you compare offers from multiple lenders.",
+  },
 };
 
 // ============================================================================

--- a/scorerebound/src/lib/email-templates.test.ts
+++ b/scorerebound/src/lib/email-templates.test.ts
@@ -49,9 +49,16 @@ describe("Email Templates", () => {
       expect(template.html).toContain("Week 12");
     });
 
-    it("includes affiliate CTAs", () => {
+    it("includes affiliate CTAs with tracking URLs", () => {
       expect(template.html).toContain("Credit Karma");
       expect(template.html).toContain("Self Credit Builder");
+      expect(template.html).toContain("/api/affiliate/click?slug=credit_karma&referrer=email-welcome");
+      expect(template.html).toContain("/api/affiliate/click?slug=self&referrer=email-welcome");
+    });
+
+    it("does not contain hardcoded affiliate base URLs", () => {
+      expect(template.html).not.toContain("https://www.creditkarma.com");
+      expect(template.html).not.toContain("https://www.self.inc");
     });
 
     it("omits plan link when not provided", () => {
@@ -90,11 +97,21 @@ describe("Email Templates", () => {
       expect(template.html).toContain("AnnualCreditReport.com");
     });
 
-    it("includes credit builder affiliate CTAs", () => {
+    it("includes credit builder affiliate CTAs with tracking URLs", () => {
       const template = weekOneEmail(BASE_PARAMS);
       expect(template.html).toContain("Self Credit Builder");
       expect(template.html).toContain("MoneyLion");
       expect(template.html).toContain("Chime");
+      expect(template.html).toContain("/api/affiliate/click?slug=self&referrer=email-week-1");
+      expect(template.html).toContain("/api/affiliate/click?slug=moneylion&referrer=email-week-1");
+      expect(template.html).toContain("/api/affiliate/click?slug=chime&referrer=email-week-1");
+    });
+
+    it("does not contain hardcoded affiliate base URLs", () => {
+      const template = weekOneEmail(BASE_PARAMS);
+      expect(template.html).not.toContain("https://www.self.inc");
+      expect(template.html).not.toContain("https://www.moneylion.com");
+      expect(template.html).not.toContain("https://www.chime.com");
     });
 
     it("includes unsubscribe link", () => {
@@ -110,11 +127,21 @@ describe("Email Templates", () => {
       expect(template.html).toContain("autopay");
     });
 
-    it("includes credit monitoring affiliate CTAs", () => {
+    it("includes credit monitoring affiliate CTAs with tracking URLs", () => {
       const template = weekFourEmail(BASE_PARAMS);
       expect(template.html).toContain("Credit Karma");
       expect(template.html).toContain("Experian");
       expect(template.html).toContain("CreditWise");
+      expect(template.html).toContain("/api/affiliate/click?slug=credit_karma&referrer=email-week-4");
+      expect(template.html).toContain("/api/affiliate/click?slug=experian&referrer=email-week-4");
+      expect(template.html).toContain("/api/affiliate/click?slug=capital_one_creditwise&referrer=email-week-4");
+    });
+
+    it("does not contain hardcoded affiliate base URLs", () => {
+      const template = weekFourEmail(BASE_PARAMS);
+      expect(template.html).not.toContain("https://www.creditkarma.com");
+      expect(template.html).not.toContain("https://www.experian.com");
+      expect(template.html).not.toContain("https://www.capitalone.com");
     });
 
     it("includes plan link when provided", () => {
@@ -140,11 +167,21 @@ describe("Email Templates", () => {
       expect(template.html).toContain("losing access to federal");
     });
 
-    it("includes refinancing affiliate CTAs", () => {
+    it("includes refinancing affiliate CTAs with tracking URLs", () => {
       const template = weekTwelveEmail(BASE_PARAMS);
       expect(template.html).toContain("SoFi");
       expect(template.html).toContain("Earnest");
       expect(template.html).toContain("Splash");
+      expect(template.html).toContain("/api/affiliate/click?slug=sofi_refi&referrer=email-week-12");
+      expect(template.html).toContain("/api/affiliate/click?slug=earnest&referrer=email-week-12");
+      expect(template.html).toContain("/api/affiliate/click?slug=splash&referrer=email-week-12");
+    });
+
+    it("does not contain hardcoded affiliate base URLs", () => {
+      const template = weekTwelveEmail(BASE_PARAMS);
+      expect(template.html).not.toContain("https://www.sofi.com");
+      expect(template.html).not.toContain("https://www.earnest.com");
+      expect(template.html).not.toContain("https://www.splashfinancial.com");
     });
 
     it("includes recovery continuation tips", () => {

--- a/scorerebound/src/lib/email-templates.ts
+++ b/scorerebound/src/lib/email-templates.ts
@@ -78,15 +78,23 @@ function ctaButton(text: string, url: string): string {
 </table>`;
 }
 
-function affiliateSection(title: string, items: { name: string; description: string; url: string }[]): string {
+function affiliateSection(
+  title: string,
+  items: { name: string; description: string; slug: string }[],
+  siteUrl: string,
+  referrer: string,
+): string {
   const rows = items
     .map(
-      (item) => `<tr>
+      (item) => {
+        const trackingUrl = `${siteUrl}/api/affiliate/click?slug=${encodeURIComponent(item.slug)}&referrer=${encodeURIComponent(referrer)}`;
+        return `<tr>
         <td style="padding:12px 0;border-bottom:1px solid #f3f4f6;">
-          <a href="${item.url}" style="font-size:15px;font-weight:600;color:#059669;text-decoration:none;">${item.name}</a>
+          <a href="${trackingUrl}" style="font-size:15px;font-weight:600;color:#059669;text-decoration:none;">${item.name}</a>
           <p style="margin:4px 0 0;font-size:13px;color:#6b7280;">${item.description}</p>
         </td>
-      </tr>`,
+      </tr>`;
+      },
     )
     .join("");
 
@@ -162,14 +170,14 @@ export function welcomeEmail(params: EmailTemplateParams): EmailTemplate {
       {
         name: "Credit Karma",
         description: "Free credit score monitoring — see where you stand right now.",
-        url: "https://www.creditkarma.com",
+        slug: "credit_karma",
       },
       {
         name: "Self Credit Builder",
         description: "Build credit with small monthly payments (no credit check to apply).",
-        url: "https://www.self.inc",
+        slug: "self",
       },
-    ])}
+    ], params.siteUrl, "email-welcome")}
     <p style="margin:24px 0 0;font-size:13px;color:#9ca3af;">
       Reply to this email if you have any questions. We're here to help.
     </p>`;
@@ -257,19 +265,19 @@ export function weekOneEmail(params: EmailTemplateParams): EmailTemplate {
       {
         name: "Self Credit Builder Loan",
         description: "Build credit history with payments starting at $25/month. No credit check required.",
-        url: "https://www.self.inc",
+        slug: "self",
       },
       {
         name: "MoneyLion Credit Builder Plus",
         description: "0% APR credit-builder loan with credit monitoring included.",
-        url: "https://www.moneylion.com",
+        slug: "moneylion",
       },
       {
         name: "Chime Credit Builder Card",
         description: "Secured card with no annual fee, no interest, no credit check.",
-        url: "https://www.chime.com/credit-builder",
+        slug: "chime",
       },
-    ])}`;
+    ], params.siteUrl, "email-week-1")}`;
 
   return {
     subject: "Week 1: Your Step-by-Step Guide to Start Recovering",
@@ -333,19 +341,19 @@ export function weekFourEmail(params: EmailTemplateParams): EmailTemplate {
       {
         name: "Credit Karma",
         description: "Free TransUnion and Equifax scores, updated weekly. Personalized recommendations.",
-        url: "https://www.creditkarma.com",
+        slug: "credit_karma",
       },
       {
         name: "Experian Free Credit Monitoring",
         description: "Free Experian score and FICO score. Dark web monitoring included.",
-        url: "https://www.experian.com/consumer-products/free-credit-monitoring.html",
+        slug: "experian",
       },
       {
         name: "Capital One CreditWise",
         description: "Free TransUnion score and credit simulator. No Capital One account needed.",
-        url: "https://www.capitalone.com/creditwise",
+        slug: "capital_one_creditwise",
       },
-    ])}`;
+    ], params.siteUrl, "email-week-4")}`;
 
   return {
     subject: "Week 4: Your Credit Recovery Progress Check-In",
@@ -402,19 +410,19 @@ export function weekTwelveEmail(params: EmailTemplateParams): EmailTemplate {
       {
         name: "SoFi Student Loan Refinancing",
         description: "Check your rate in 2 minutes. No fees, no prepayment penalties. Rates from 4.49% APR.",
-        url: "https://www.sofi.com/refinance-student-loan",
+        slug: "sofi_refi",
       },
       {
         name: "Earnest Student Loan Refinancing",
         description: "Customize your monthly payment. Skip a payment once a year. Rates from 4.49% APR.",
-        url: "https://www.earnest.com/student-loan-refinancing",
+        slug: "earnest",
       },
       {
         name: "Splash Financial",
         description: "Compare rates from multiple lenders in one application. Quick prequalification.",
-        url: "https://www.splashfinancial.com",
+        slug: "splash",
       },
-    ])}
+    ], params.siteUrl, "email-week-12")}
     <h3 style="margin:24px 0 12px;font-size:17px;color:#111827;">What's Next?</h3>
     <p style="margin:0 0 16px;font-size:15px;line-height:1.6;color:#374151;">
       This is our last scheduled email, but your recovery journey continues. Keep doing what's working:


### PR DESCRIPTION
## Summary

- Refactored `affiliateSection()` in `email-templates.ts` to accept `siteUrl` and `referrer` parameters, generating tracking URLs via `/api/affiliate/click?slug=...&referrer=...` instead of hardcoded base URLs
- All 4 drip campaign emails (welcome, week-1, week-4, week-12) now route affiliate clicks through the tracking endpoint with step-specific referrer tags
- Added 3 new affiliate products to the catalog (`moneylion`, `chime`, `capital_one_creditwise`) that were referenced in email templates but missing from `affiliates.ts`
- Updated unit tests to verify tracking URLs are generated and hardcoded affiliate base URLs are absent

Closes #315

## Test plan

- [x] All 145 unit tests pass (`bun run test`)
- [x] Lint clean (`bun run lint`)
- [x] Build succeeds (`bun run build`)
- [x] `validate-pr.sh` passes with 0 errors
- [ ] Verify `/api/affiliate/click` endpoint correctly redirects when accessed with email referrer params

🤖 Generated with [Claude Code](https://claude.com/claude-code)