### PR TITLE
chore(scorerebound): close #287 — email capture and drip campaign already implemented

### DIFF
--- a/scorerebound/.env.example
+++ b/scorerebound/.env.example
@@ -11,6 +11,11 @@ NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_your-publishable-key
 
 # Resend (Email)
 RESEND_API_KEY=re_your-resend-api-key
+# Optional: custom "from" address (default: ScoreRebound <noreply@scorerebound.com>)
+# RESEND_FROM_EMAIL=ScoreRebound <noreply@scorerebound.com>
+
+# Drip campaign cron endpoint authorization
+CRON_SECRET=your-cron-secret-here
 
 # App Config
 NEXT_PUBLIC_SITE_URL=http://localhost:3000

--- a/scorerebound/CLAUDE.md
+++ b/scorerebound/CLAUDE.md
@@ -216,6 +216,12 @@ All UI components MUST follow these conventions:
 - `footer-link-privacy`, `footer-link-terms`, `footer-copyright`
 - `main-content`
 
+### Existing data-testid Attributes (Email Capture — on Plan Page)
+- `email-capture-section`, `email-capture-title`
+- `email-capture-form`, `email-capture-input`, `email-capture-submit`
+- `email-capture-success`, `email-capture-error`
+- `plan-email-section` (wrapper in PlanViewer)
+
 ### Testing Requirements
 - `TEST_MODE=true` env var enables test accounts and bypasses rate limits
 - Test user accounts seeded via environment variables
@@ -231,6 +237,7 @@ See `.env.example` for the full list. Key variables:
 - `NEXT_PUBLIC_SUPABASE_ANON_KEY` — Supabase anonymous key
 - `STRIPE_SECRET_KEY` — Stripe API secret key
 - `RESEND_API_KEY` — Resend email API key
+- `CRON_SECRET` — Authorization token for `/api/email/drip` cron endpoint
 - `TEST_MODE` — Enable test mode (`true`/`false`)
 
 **NEVER commit secrets.** Use `.env.local` for local development, `.env.example` for templates.


### PR DESCRIPTION
## Summary

Closes #287. The email capture and drip campaign feature was already fully implemented via PR #311 (email capture, drip campaign, affiliate system) and PR #321 (affiliate link tracking in emails), but issue #287 was not formally closed.

This PR adds two small documentation/config gaps found during verification:

- **`.env.example`**: Added `CRON_SECRET` (required by `/api/email/drip` cron endpoint) and documented `RESEND_FROM_EMAIL` optional override
- **`CLAUDE.md`**: Documented email capture `data-testid` attributes and `CRON_SECRET` env var

### Acceptance criteria verification (all ✅ on main)

- [x] Email capture field in quiz flow (optional, after plan generation) — `EmailCapture.tsx` rendered in `PlanViewer`
- [x] Resend integration for transactional emails — `src/lib/resend.ts`
- [x] Welcome email with recovery plan summary + affiliate links — `welcomeEmail()` in `email-templates.ts`
- [x] 3-email drip sequence:
  - [x] Week 1: IBR enrollment guide + credit builder CTA — `weekOneEmail()`
  - [x] Week 4: Progress check-in + monitoring CTA — `weekFourEmail()`
  - [x] Week 12: Refinancing eligibility check + refi CTA — `weekTwelveEmail()`
- [x] Unsubscribe in every email — `emailLayout()` footer + `/api/email/unsubscribe` endpoint
- [x] data-testid on email capture form — all elements have `data-testid` attributes

### Existing implementation summary

| Component | File |
|-----------|------|
| Email capture UI | `src/components/EmailCapture.tsx` |
| Email templates (4 drip steps) | `src/lib/email-templates.ts` |
| Resend client | `src/lib/resend.ts` |
| Subscribe API | `src/app/api/email/subscribe/route.ts` |
| Unsubscribe API | `src/app/api/email/unsubscribe/route.ts` |
| Drip cron endpoint | `src/app/api/email/drip/route.ts` |
| DB migration | `supabase/migrations/20260317000001_create_email_subscribers.sql` |
| Unit tests (50 tests) | `src/lib/email-templates.test.ts`, `src/lib/resend.test.ts` |
| E2E tests | `e2e/email-capture.spec.ts` |

## Test plan

- [x] `bun run build` — passes
- [x] `bun run test` — 145 tests pass (9 suites)
- [x] `bun run lint` — clean
- [x] `bash scripts/validate-pr.sh scorerebound` — 0 errors, 0 warnings