### PR TITLE
feat(scorerebound): embed affiliate product recommendations in recovery plan

### DIFF
--- a/scorerebound/CLAUDE.md
+++ b/scorerebound/CLAUDE.md
@@ -216,6 +216,21 @@ All UI components MUST follow these conventions:
 - `footer-link-privacy`, `footer-link-terms`, `footer-copyright`
 - `main-content`
 
+### Existing data-testid Attributes (Plan Page — PlanViewer)
+- `plan-viewer`, `plan-header`, `plan-path-badge`, `plan-timeline-badge`
+- `plan-title`, `plan-summary`, `plan-score-estimate`, `plan-score-improvement`
+- `plan-warnings`, `plan-warning-{i}`
+- `plan-steps`, `plan-step-{n}`, `plan-step-toggle-{n}`, `plan-step-detail-{n}`, `plan-step-link-{n}`
+- `plan-path-details`, `plan-cta`, `plan-save-cta`
+
+### Existing data-testid Attributes (Affiliate Recommendations — on Plan Page)
+- `plan-affiliate-section` (wrapper in PlanViewer)
+- `affiliate-card-{slug}` (card container, e.g., `affiliate-card-self`)
+- `affiliate-name-{slug}`, `affiliate-description-{slug}`, `affiliate-why-{slug}`
+- `affiliate-category-{slug}` (category badge)
+- `affiliate-cta-{slug}` (CTA link — routes through `/api/affiliate/click`)
+- `affiliate-disclosure` (FTC disclosure banner)
+
 ### Existing data-testid Attributes (Email Capture — on Plan Page)
 - `email-capture-section`, `email-capture-title`
 - `email-capture-form`, `email-capture-input`, `email-capture-submit`
@@ -244,4 +259,4 @@ See `.env.example` for the full list. Key variables:
 
 ## Version
 
-0.1.0
+0.7.0

--- a/scorerebound/package.json
+++ b/scorerebound/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scorerebound",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",


### PR DESCRIPTION
## Summary

Completes affiliate product recommendations for ScoreRebound recovery plans (closes #349). Core implementation was merged via PR #353; this PR finalizes with CLAUDE.md updates and version bump.

### What's Implemented (full feature)

- **AffiliateCard component** (`src/components/AffiliateCard.tsx`): Product recommendation card with name, category badge, description, why recommended, and CTA button
- **Typed product catalog** (`src/lib/affiliates.ts` + `src/lib/affiliate-products.ts`): 11 affiliate products across 4 categories (credit-builder, secured-card, credit-monitoring, refinancing)
- **Contextual matching logic**: Credit-builder and secured cards for low/mid scores; monitoring for all paths/scores; refinancing only for high scores on eligible paths (IBR, credit-building). Max 3 products per plan.
- **Integration in PlanViewer**: Affiliate section renders below recovery steps on `/plan/[id]`, using recovery_path + scoreRange from quiz for contextual matching
- **Tracking**: All affiliate links route through `/api/affiliate/click?slug={slug}&referrer={page}` — zero hardcoded external URLs
- **FTC compliance**: Disclosure banner with `data-testid="affiliate-disclosure"`
- **Link attributes**: `rel="noopener noreferrer sponsored"` on all affiliate CTAs
- **Tests**: 14 Vitest unit tests for matching logic + 8 Playwright E2E tests verifying cards, disclosure, tracking URLs, score-based filtering, category badges
- **CLAUDE.md**: Updated with all affiliate-related `data-testid` attributes and plan page testids

### Revenue Chain
Quiz → Recovery Plan → Contextual Affiliate Cards → Click → Commission ($5-300/conversion)

### Acceptance Criteria Verification

- [x] `src/components/AffiliateCard.tsx` exists with data-testid
- [x] `src/lib/affiliate-products.ts` exists with typed catalog
- [x] All links route through `/api/affiliate/click`
- [x] Cards embedded in `/plan/[id]` with 2-3 contextual recommendations
- [x] Contextual matching: credit-builders for low scores, refinancing for high scores only
- [x] FTC disclosure with `data-testid="affiliate-disclosure"`
- [x] `rel="noopener sponsored"` on all affiliate links
- [x] 14 Vitest unit tests (8 matching logic + 6 utility functions)
- [x] 8 Playwright E2E tests (quiz→plan→affiliate flow)
- [x] `bun run build` ✅
- [x] `bun run test` ✅ (145 tests, 9 files)
- [x] `bun run lint` ✅
- [x] `validate-pr.sh` ✅ (0 errors, 0 warnings)

## Test plan

- [ ] Verify build, test, lint pass in CI
- [ ] Verify Claude and Gemini code reviews pass
- [ ] Verify no scope creep (changes scoped to `scorerebound/` only)
- [ ] Run E2E tests against preview deployment