### PR TITLE
feat(afterloss): county-level programmatic SEO pages (closes #266)

### DIFF
--- a/afterloss/CLAUDE.md
+++ b/afterloss/CLAUDE.md
@@ -280,4 +280,4 @@ Security headers are configured in `next.config.ts`:
 7. Deploy
 
 ## Version
-0.5.1
+0.6.0

--- a/afterloss/package.json
+++ b/afterloss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "afterloss",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/afterloss/src/app/probate/[state]/[county]/page.tsx
+++ b/afterloss/src/app/probate/[state]/[county]/page.tsx
@@ -49,8 +49,6 @@ export async function generateMetadata({
     title,
     description,
     openGraph: {
-      title,
-      description,
       url: `${BASE_URL}/probate/${stateSlug}/${countySlug}`,
     },
     alternates: {


### PR DESCRIPTION
## Summary

Finalizes county-level programmatic SEO pages for AfterLoss, closing #266. WIP PR #369 implemented all MUST requirements; this PR completes the issue by fixing metadata and bumping the version.

**What's included (from WIP #369 + this PR):**
- **219 county probate court guide pages** across 40+ states — top 200 US counties by population (~50% of US population)
- County data types (`types.ts`) and Phase 1 data (`counties-phase1.ts`) with court names, addresses, phones, websites, filing fees, timelines, populations, FIPS codes
- SSG pages at `/probate/[state]/[county]` with `generateStaticParams()`
- JSON-LD structured data (GovernmentOffice + BreadcrumbList + FAQPage schemas)
- Meta tags targeting "[county] [state] probate court" queries
- State probate pages link down to their county sub-pages
- Related counties sidebar on each county page
- County pages included in `sitemap.ts`
- `data-testid` attributes on all interactive elements
- **Fix**: Removed duplicate title/description in openGraph metadata per learnings (Next.js auto-populates from top-level)
- **Version**: 0.5.1 → 0.6.0

**Data quality verified by tests:**
- All 219 counties have valid required fields (name, state code, FIPS, court info, phone, population, verified date)
- FIPS codes consistent with state codes
- Top 10 most populous US counties included
- 90%+ have court website URLs
- No duplicate FIPS codes
- All counties round-trip through slug functions

## Test plan

- [x] `bun run build` exits 0 (411 pages generated, 219 county pages)
- [x] `bun run test` exits 0 (354 tests pass, including 21 county data + 21 slug tests)
- [x] `bun run lint` exits 0
- [x] `bash scripts/validate-pr.sh afterloss` — 0 errors, 0 warnings
- [x] All issue acceptance test commands pass
- [x] No scope creep — only `afterloss/` files changed