### PR TITLE
feat(billwatch): finalize EIA API v2 integration (closes #331)

### DIFF
--- a/billwatch/CLAUDE.md
+++ b/billwatch/CLAUDE.md
@@ -218,4 +218,4 @@ Security headers are configured in `next.config.ts`:
 - Health check: `GET /api/health` returns `{ "status": "ok" }`
 
 ## Version
-0.5.0
+0.6.0

--- a/billwatch/package.json
+++ b/billwatch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billwatch",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack --port 3001",

--- a/billwatch/src/lib/eia/client.test.ts
+++ b/billwatch/src/lib/eia/client.test.ts
@@ -5,6 +5,7 @@ import {
   buildEiaUrl,
   clearCache,
   getCacheSize,
+  expireCache,
 } from "./client";
 
 // Mock env module so getEiaApiKey doesn't throw
@@ -136,7 +137,7 @@ describe("getStateRates", () => {
     );
   });
 
-  it("returns stale cache on API error", async () => {
+  it("returns stale cache on API error when cache is expired", async () => {
     // First call succeeds and populates cache
     const mockResponse = makeEiaResponse([
       { period: "2026-01", stateid: "NY", price: 24.3 },
@@ -145,21 +146,20 @@ describe("getStateRates", () => {
       new Response(JSON.stringify(mockResponse), { status: 200 }),
     );
     await getStateRates("NY");
+    expect(getCacheSize()).toBe(1);
 
-    // Expire the cache manually by clearing and re-setting with past expiry
-    // We simulate stale cache by directly manipulating - use the cache module
-    clearCache();
+    // Expire the cache entries so the next call must re-fetch
+    expireCache();
 
-    // Repopulate with expired entry via a fresh fetch, then fail
+    // Second call fails — should fall back to stale cached data
     vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
-      new Response(JSON.stringify(mockResponse), { status: 200 }),
+      new Response("Service Unavailable", { status: 503, statusText: "Service Unavailable" }),
     );
-    const fresh = await getStateRates("NY");
-    expect(fresh).not.toBeNull();
 
-    // Now the cache is populated and valid — this call should use cache
-    const cached = await getStateRates("NY");
-    expect(cached!.stateCode).toBe("NY");
+    const result = await getStateRates("NY");
+    expect(result).not.toBeNull();
+    expect(result!.stateCode).toBe("NY");
+    expect(result!.currentRate).toBe(24.3);
   });
 
   it("handles unexpected response format", async () => {

--- a/billwatch/src/lib/eia/client.ts
+++ b/billwatch/src/lib/eia/client.ts
@@ -26,6 +26,9 @@ interface CacheEntry<T> {
 /** 24-hour cache TTL in milliseconds — EIA data updates monthly */
 const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
 
+/** Number of rows for all-state bulk fetch: 51 jurisdictions × 12 months */
+const ALL_STATES_ROW_COUNT = 51 * 12;
+
 /** In-memory cache keyed by state code (or "ALL" for all states) */
 const cache = new Map<string, CacheEntry<StateRateData>>();
 
@@ -37,6 +40,13 @@ export function clearCache(): void {
 /** Visible for testing — returns cache size */
 export function getCacheSize(): number {
   return cache.size;
+}
+
+/** Visible for testing — expire all cache entries so the next fetch bypasses cache */
+export function expireCache(): void {
+  for (const [key, entry] of cache) {
+    cache.set(key, { ...entry, expiresAt: 0 });
+  }
 }
 
 /**
@@ -113,12 +123,10 @@ function transformToStateRateData(
 
   const latest = stateRows[0];
 
-  const rateHistory: RateHistoryEntry[] = stateRows
-    .filter((r) => r.price !== null)
-    .map((r) => ({
-      period: r.period,
-      price: r.price as number,
-    }));
+  const rateHistory: RateHistoryEntry[] = stateRows.map((r) => ({
+    period: r.period,
+    price: r.price as number,
+  }));
 
   return {
     stateCode: latest.stateid,
@@ -186,8 +194,7 @@ export async function getStateRates(
  * @throws If the EIA API is unreachable and no cached data exists
  */
 export async function getAllStateRates(): Promise<Map<string, StateRateData>> {
-  // Fetch all states in one call — request enough rows for 51 states × 12 months
-  const url = buildEiaUrl(undefined, 612);
+  const url = buildEiaUrl(undefined, ALL_STATES_ROW_COUNT);
   const rows = await fetchEiaData(url);
 
   // Group rows by state

--- a/billwatch/src/lib/env.test.ts
+++ b/billwatch/src/lib/env.test.ts
@@ -1,23 +1,75 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { isTestMode } from "./env";
+import {
+  isTestMode,
+  getSupabaseUrl,
+  getSupabaseAnonKey,
+  getStripeSecretKey,
+  getEiaApiKey,
+} from "./env";
 
 describe("env helpers", () => {
   beforeEach(() => {
     vi.unstubAllEnvs();
   });
 
-  it("isTestMode returns true when TEST_MODE=true", () => {
-    vi.stubEnv("TEST_MODE", "true");
-    expect(isTestMode()).toBe(true);
+  describe("isTestMode", () => {
+    it("returns true when TEST_MODE=true", () => {
+      vi.stubEnv("TEST_MODE", "true");
+      expect(isTestMode()).toBe(true);
+    });
+
+    it("returns false when TEST_MODE is not set", () => {
+      vi.stubEnv("TEST_MODE", "");
+      expect(isTestMode()).toBe(false);
+    });
+
+    it("returns false when TEST_MODE=false", () => {
+      vi.stubEnv("TEST_MODE", "false");
+      expect(isTestMode()).toBe(false);
+    });
   });
 
-  it("isTestMode returns false when TEST_MODE is not set", () => {
-    vi.stubEnv("TEST_MODE", "");
-    expect(isTestMode()).toBe(false);
+  describe("getSupabaseUrl", () => {
+    it("returns the URL when set", () => {
+      vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "https://test.supabase.co");
+      expect(getSupabaseUrl()).toBe("https://test.supabase.co");
+    });
+
+    it("throws when not set", () => {
+      expect(() => getSupabaseUrl()).toThrow("NEXT_PUBLIC_SUPABASE_URL is not set");
+    });
   });
 
-  it("isTestMode returns false when TEST_MODE=false", () => {
-    vi.stubEnv("TEST_MODE", "false");
-    expect(isTestMode()).toBe(false);
+  describe("getSupabaseAnonKey", () => {
+    it("returns the key when set", () => {
+      vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", "test-anon-key");
+      expect(getSupabaseAnonKey()).toBe("test-anon-key");
+    });
+
+    it("throws when not set", () => {
+      expect(() => getSupabaseAnonKey()).toThrow("NEXT_PUBLIC_SUPABASE_ANON_KEY is not set");
+    });
+  });
+
+  describe("getStripeSecretKey", () => {
+    it("returns the key when set", () => {
+      vi.stubEnv("STRIPE_SECRET_KEY", "sk_test_123");
+      expect(getStripeSecretKey()).toBe("sk_test_123");
+    });
+
+    it("throws when not set", () => {
+      expect(() => getStripeSecretKey()).toThrow("STRIPE_SECRET_KEY is not set");
+    });
+  });
+
+  describe("getEiaApiKey", () => {
+    it("returns the key when set", () => {
+      vi.stubEnv("EIA_API_KEY", "test-eia-key");
+      expect(getEiaApiKey()).toBe("test-eia-key");
+    });
+
+    it("throws when not set", () => {
+      expect(() => getEiaApiKey()).toThrow("EIA_API_KEY is not set");
+    });
   });
 });


### PR DESCRIPTION
## Summary

Completes the EIA API v2 integration from WIP PR #372, addressing all MEDIUM review findings.

**What was already in place from WIP (#372):**
- Typed EIA API v2 client (`src/lib/eia/client.ts`) with `getStateRates()` and `getAllStateRates()`
- TypeScript types for EIA API responses (`src/types/eia.ts`)
- API route `GET /api/rates/[state]` with validation, 24h caching, and error handling
- Benchmarking helper (`src/lib/eia/benchmarks.ts`) comparing user rates against state/national averages
- 21 unit tests across client and benchmarks

**What this PR adds (quality fixes from review findings):**
- Remove redundant `.filter(r => r.price !== null)` in `transformToStateRateData` — the upstream filter already guarantees non-null prices
- Replace magic number `612` with named constant `ALL_STATES_ROW_COUNT` (51 jurisdictions × 12 months)
- Fix stale cache test: add `expireCache()` helper to properly test expired-cache fallback instead of the previous test that only verified fresh cache hits
- Add comprehensive `env.test.ts` coverage: all getter error paths (`getEiaApiKey`, `getSupabaseUrl`, `getSupabaseAnonKey`, `getStripeSecretKey`) now tested for throw behavior when env vars are missing
- Bump version to 0.6.0

**Test results:** 175 tests pass, lint clean, build clean.

Closes #331

## Test plan

- [x] `bun run test` — 175 tests pass (up from 167)
- [x] `bun run lint` — no warnings or errors
- [x] `bun run build` — compiles successfully
- [x] All changes scoped to `billwatch/`
- [x] No pre-existing files deleted