### PR TITLE
feat(ghostboard): complete database schema — fix RLS, stats, tests (closes #272)

### DIFF
--- a/ghostboard/.env.example
+++ b/ghostboard/.env.example
@@ -6,5 +6,5 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
 STRIPE_SECRET_KEY=sk_test_your-stripe-secret-key
 
 # App
-TEST_MODE=true
+TEST_MODE=false
 NEXT_PUBLIC_APP_URL=http://localhost:3000

--- a/ghostboard/CLAUDE.md
+++ b/ghostboard/CLAUDE.md
@@ -141,4 +141,4 @@ See `.env.example` for required variables:
 - `NEXT_PUBLIC_APP_URL` -- Public app URL
 
 ## Version
-0.1.0
+0.2.0

--- a/ghostboard/package.json
+++ b/ghostboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ghostboard",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/ghostboard/src/lib/env.test.ts
+++ b/ghostboard/src/lib/env.test.ts
@@ -1,23 +1,68 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { isTestMode } from "./env";
+import {
+  isTestMode,
+  getSupabaseUrl,
+  getSupabaseAnonKey,
+  getStripeSecretKey,
+} from "./env";
 
 describe("env helpers", () => {
   beforeEach(() => {
     vi.unstubAllEnvs();
   });
 
-  it("isTestMode returns true when TEST_MODE=true", () => {
-    vi.stubEnv("TEST_MODE", "true");
-    expect(isTestMode()).toBe(true);
+  describe("isTestMode", () => {
+    it("returns true when TEST_MODE=true", () => {
+      vi.stubEnv("TEST_MODE", "true");
+      expect(isTestMode()).toBe(true);
+    });
+
+    it("returns false when TEST_MODE is not set", () => {
+      expect(isTestMode()).toBe(false);
+    });
+
+    it("returns false when TEST_MODE=false", () => {
+      vi.stubEnv("TEST_MODE", "false");
+      expect(isTestMode()).toBe(false);
+    });
   });
 
-  it("isTestMode returns false when TEST_MODE is not set", () => {
-    vi.stubEnv("TEST_MODE", "");
-    expect(isTestMode()).toBe(false);
+  describe("getSupabaseUrl", () => {
+    it("returns the URL when set", () => {
+      vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "https://test.supabase.co");
+      expect(getSupabaseUrl()).toBe("https://test.supabase.co");
+    });
+
+    it("throws when NEXT_PUBLIC_SUPABASE_URL is not set", () => {
+      expect(() => getSupabaseUrl()).toThrow(
+        "NEXT_PUBLIC_SUPABASE_URL is not set",
+      );
+    });
   });
 
-  it("isTestMode returns false when TEST_MODE=false", () => {
-    vi.stubEnv("TEST_MODE", "false");
-    expect(isTestMode()).toBe(false);
+  describe("getSupabaseAnonKey", () => {
+    it("returns the key when set", () => {
+      vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", "test-anon-key");
+      expect(getSupabaseAnonKey()).toBe("test-anon-key");
+    });
+
+    it("throws when NEXT_PUBLIC_SUPABASE_ANON_KEY is not set", () => {
+      expect(() => getSupabaseAnonKey()).toThrow(
+        "NEXT_PUBLIC_SUPABASE_ANON_KEY is not set",
+      );
+    });
+  });
+
+  describe("getStripeSecretKey", () => {
+    it("returns the key when set", () => {
+      vi.stubEnv("STRIPE_SECRET_KEY", "sk_test_123");
+      expect(getStripeSecretKey()).toBe("sk_test_123");
+    });
+
+    it("throws when STRIPE_SECRET_KEY is not set", () => {
+      expect(() => getStripeSecretKey()).toThrow(
+        "STRIPE_SECRET_KEY is not set",
+      );
+    });
   });
 });

--- a/ghostboard/supabase/config.toml
+++ b/ghostboard/supabase/config.toml
@@ -302,6 +302,18 @@ max_frequency = "5s"
 # Use an external OAuth provider. The full list of providers are: `apple`, `azure`, `bitbucket`,
 # `discord`, `facebook`, `github`, `gitlab`, `google`, `keycloak`, `linkedin_oidc`, `notion`, `twitch`,
 # `twitter`, `x`, `slack`, `spotify`, `workos`, `zoom`.
+[auth.external.google]
+enabled = true
+client_id = "env(SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID)"
+# DO NOT commit your OAuth provider secret to git. Use environment variable substitution instead:
+secret = "env(SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET)"
+# Overrides the default auth redirectUrl.
+redirect_uri = ""
+# Overrides the default auth provider URL.
+url = ""
+# Required for local sign in with Google auth.
+skip_nonce_check = true
+
 [auth.external.apple]
 enabled = false
 client_id = ""

--- a/ghostboard/supabase/migrations/00002_fix_rls_and_stats.sql
+++ b/ghostboard/supabase/migrations/00002_fix_rls_and_stats.sql
@@ -1,0 +1,103 @@
+-- GhostBoard Schema Fix: RLS policies and materialized view calculations
+-- Migration: 00002_fix_rls_and_stats
+-- Fixes HIGH findings from PR #377 review:
+--   1. companies UPDATE policy too permissive (any authenticated user could update any company)
+--   2. Materialized view ghosting_rate/avg_response_days don't properly weight old reports
+
+-- =============================================================================
+-- Fix 1: Restrict companies UPDATE to users with approved claims
+-- Previously: any authenticated user could update any company
+-- Now: only users with an approved company_claim can update
+-- =============================================================================
+
+DROP POLICY IF EXISTS "companies_update_auth" ON companies;
+
+CREATE POLICY "companies_update_claimed"
+  ON companies FOR UPDATE
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM company_claims
+      WHERE company_claims.company_id = companies.id
+      AND company_claims.user_id = auth.uid()
+      AND company_claims.status = 'approved'
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM company_claims
+      WHERE company_claims.company_id = companies.id
+      AND company_claims.user_id = auth.uid()
+      AND company_claims.status = 'approved'
+    )
+  );
+
+-- =============================================================================
+-- Fix 2: Rebuild materialized view with proper weighted calculations
+-- Old reports (>2 years) get 0.5 weight in both ghosting_rate and avg_response_days.
+-- Uses weighted sum / weight total instead of halving the raw values.
+-- =============================================================================
+
+DROP MATERIALIZED VIEW IF EXISTS company_stats;
+
+CREATE MATERIALIZED VIEW company_stats AS
+SELECT
+  c.id AS company_id,
+  COUNT(r.id) AS total_reports,
+  -- Weighted ghosting rate: old reports count half
+  ROUND(
+    SUM(
+      CASE
+        WHEN r.status = 'ghosted' AND r.created_at >= NOW() - INTERVAL '2 years' THEN 1.0
+        WHEN r.status = 'ghosted' THEN 0.5
+        ELSE 0
+      END
+    ) / NULLIF(
+      SUM(
+        CASE
+          WHEN r.created_at >= NOW() - INTERVAL '2 years' THEN 1.0
+          ELSE 0.5
+        END
+      ), 0
+    ) * 100, 1
+  ) AS ghosting_rate,
+  -- Weighted avg response days: old reports count half
+  ROUND(
+    (
+      SUM(
+        CASE
+          WHEN r.response_days IS NOT NULL AND r.created_at >= NOW() - INTERVAL '2 years' THEN r.response_days * 1.0
+          WHEN r.response_days IS NOT NULL THEN r.response_days * 0.5
+          ELSE 0
+        END
+      ) / NULLIF(
+        SUM(
+          CASE
+            WHEN r.response_days IS NOT NULL AND r.created_at >= NOW() - INTERVAL '2 years' THEN 1.0
+            WHEN r.response_days IS NOT NULL THEN 0.5
+            ELSE 0
+          END
+        ), 0
+      )
+    )::NUMERIC, 1
+  ) AS avg_response_days,
+  ROUND(
+    COUNT(r.id) FILTER (WHERE r.status = 'offered')::NUMERIC
+    / NULLIF(COUNT(r.id) FILTER (WHERE r.status = 'interviewed'), 0) * 100, 1
+  ) AS interview_to_offer_ratio,
+  MAX(r.created_at) AS last_report_at
+FROM companies c
+JOIN reports r ON r.company_id = c.id AND r.is_flagged = FALSE
+GROUP BY c.id
+HAVING COUNT(r.id) >= 5
+WITH DATA;
+
+CREATE UNIQUE INDEX idx_company_stats_company_id ON company_stats(company_id);
+
+-- Recreate refresh function (references the view)
+CREATE OR REPLACE FUNCTION refresh_company_stats()
+RETURNS VOID AS $$
+BEGIN
+  REFRESH MATERIALIZED VIEW CONCURRENTLY company_stats;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;


### PR DESCRIPTION
## Summary

Completes the GhostBoard database schema work from issue #272, fixing the HIGH findings identified during PR #377 review:

- **Migration 00002**: Restricts `companies` UPDATE policy to users with approved `company_claims` (was: any authenticated user could update any company)
- **Migration 00002**: Rebuilds `company_stats` materialized view with proper weighted averages — old reports (>2 years) get 0.5 weight in both numerator and denominator for `ghosting_rate` and `avg_response_days`
- **Env tests**: Adds missing error-throwing tests for `getSupabaseUrl`, `getSupabaseAnonKey`, `getStripeSecretKey` (per learnings)
- **Google OAuth**: Enables Google OAuth provider in `supabase/config.toml` (SHOULD item)
- **Fixes**: `.env.example` defaults `TEST_MODE=false` (per learnings)
- **Version**: Bumps to 0.2.0

## What was already done (PR #377, merged)

The base schema with all 5 tables, materialized view, seed data, TypeScript types, Supabase client, and RLS policies was merged as WIP. This PR addresses the review gaps.

## Files changed

| File | Change |
|------|--------|
| `supabase/migrations/00002_fix_rls_and_stats.sql` | New migration fixing RLS + materialized view |
| `src/lib/env.test.ts` | Added 6 new tests for env getter error paths |
| `supabase/config.toml` | Added Google OAuth provider |
| `.env.example` | Fixed TEST_MODE default |
| `package.json` | Version bump to 0.2.0 |
| `CLAUDE.md` | Version bump to 0.2.0 |

## Test plan

- [x] `bun run test` — 40 tests pass (4 files)
- [x] `bun run build` — clean build
- [x] `bun run lint` — no warnings or errors
- [x] `bash scripts/validate-pr.sh ghostboard` — 0 errors, 0 warnings
- [x] No scope creep — all changes under `ghostboard/`
- [ ] Verify migration applies cleanly against Supabase instance